### PR TITLE
Fix 'get' command message when content exists but completezip does not

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,13 @@
 Change Log
 ==========
 
+3.0.1
+-----
+
+- Fix 'get' issue where the content exists but the completezip is not
+  available for download.
+  See https://github.com/Connexions/nebuchadnezzar/issues/28
+
 3.0.0
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -159,6 +159,9 @@ def get(ctx, env, col_id, col_version, output_dir):
     if not resp:
         logger.debug("Response code is {}".format(resp.status_code))
         raise MissingContent(col_id, col_version)
+    elif resp.status_code == 204:
+        logger.info("The content exists, but the completezip is missing")
+        raise MissingContent(col_id, col_version)
 
     content_size = int(resp.headers['Content-Length'].strip())
     label = 'Downloading {}'.format(col_id)

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -280,6 +280,27 @@ class TestGetCmd:
         msg = "content unavailable for '{}/latest'".format(col_id)
         assert msg in result.output
 
+    def test_unavailable_completezip(self, requests_mocker, invoker):
+        # This case is possible when the content exists, but the completezip
+        # has not been produced.
+        col_id = 'col00000'
+        url = ('https://legacy.cnx.org/content/{}/latest/complete'
+               .format(col_id))
+
+        requests_mocker.register_uri('GET', url, status_code=204)
+
+        from nebu.cli.main import cli
+        args = ['get', 'test-env', col_id]
+        result = invoker(cli, args)
+
+        assert result.exit_code == 4
+
+        msg = "The content exists, but the completezip is missing"
+        assert msg in result.output
+
+        msg = "content unavailable for '{}/latest'".format(col_id)
+        assert msg in result.output
+
 
 class TestValidateCmd:
 


### PR DESCRIPTION
```
> neb get dev col11629
Traceback (most recent call last):
  File "/Users/pumazi/.environments/c/bin/neb", line 11, in <module>
    load_entry_point('nebuchadnezzar', 'console_scripts', 'neb')()
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/pumazi/cnx/src/nebuchadnezzar/nebu/cli/main.py", line 163, in get
    content_size = int(resp.headers['Content-Length'].strip())
  File "/Users/pumazi/.environments/c/lib/python3.5/site-packages/requests/structures.py", line 54, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'content-length'
```

This now returns a message instead:

```
> neb get dev col11629
The content exists, but the completezip is missing
Error: content unavailable for 'col11629/latest'
```

Fixes #28 