### PR TITLE
Fix spacing when generating sha1sum files

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+8.0.4
+-----
+
+- Fix spacing when generating sha1sum files on `get`.
+
 8.0.3
 -----
 

--- a/nebu/cli/get.py
+++ b/nebu/cli/get.py
@@ -116,7 +116,7 @@ def gen_resources_sha1_cache(write_dir, resources):
     for resource in resources:
         with (write_dir / '.sha1sum').open('a') as s:
             # NOTE: the id is the sha1
-            s.write('{} {}\n'.format(resource['id'], resource['filename']))
+            s.write('{}  {}\n'.format(resource['id'], resource['filename']))
 
 
 def _write_node(node, base_url, out_dir, book_tree=False,


### PR DESCRIPTION
Spacing mismatch caused an exception to be thrown.

```
Traceback (most recent call last):
 File "/usr/local/bin/neb", line 11, in <module>
   sys.exit(cli())
 File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
   return self.main(*args, **kwargs)
 File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
   rv = self.invoke(ctx)
 File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
   return _process_result(sub_ctx.command.invoke(sub_ctx))
 File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
   return ctx.invoke(self.callback, **ctx.params)
 File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
   return callback(*args, **kwargs)
 File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
   return f(get_current_context(), *args, **kwargs)
 File "/usr/local/lib/python3.7/site-packages/nebu/cli/_common.py", line 54, in wrapper
   return func(*args, **kwargs)
 File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
   return f(get_current_context(), *args, **kwargs)
 File "/usr/local/lib/python3.7/site-packages/nebu/cli/publish.py", line 219, in publish
   struct = parse_book_tree(content_dir)
 File "/usr/local/lib/python3.7/site-packages/nebu/cli/publish.py", line 27, in parse_book_tree
   sha1s = get_sha1s_dict(path)
 File "/usr/local/lib/python3.7/site-packages/nebu/cli/publish.py", line 42, in get_sha1s_dict
   for line in sha_file if not line.startswith('#')}
 File "/usr/local/lib/python3.7/site-packages/nebu/cli/publish.py", line 42, in <dictcomp>
   for line in sha_file if not line.startswith('#')}
IndexError: list index out of range
```