### PR TITLE
Add cnxml-to-html command to transform index.cnxml to html

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+9.1.0
+-----
+
+- Add ``cnxml-to-html`` command to transform index.cnxml to html.
+
 9.0.1
 -----
 

--- a/nebu/cli/cnxml_to_html.py
+++ b/nebu/cli/cnxml_to_html.py
@@ -1,0 +1,22 @@
+import os
+
+import click
+from cnxtransforms import cnxml_to_full_html
+
+from ._common import common_params
+
+
+@click.command()
+@common_params
+@click.argument('collection_path')
+def cnxml_to_html(collection_path):
+    """Given a collection COLLECTION_PATH (downloaded using neb get or complete
+    zip on the cnx site), transform all the index.cnxml to index.cnxml.html"""
+
+    for root, dirs, files in os.walk(collection_path):
+        if 'index.cnxml' in files:
+            index_cnxml_path = os.path.join(root, 'index.cnxml')
+            with open(index_cnxml_path) as f:
+                index_cnxml = f.read()
+            with open('{}.html'.format(index_cnxml_path), 'w') as f:
+                f.write(cnxml_to_full_html(index_cnxml))

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -8,6 +8,7 @@ from nebu import __version__
 from ..config import prepare
 
 from .atom import config_atom
+from .cnxml_to_html import cnxml_to_html
 from .get import get
 from .environment import list_environments
 from .publish import publish
@@ -93,6 +94,7 @@ def cli(ctx):
     ctx.obj = env
 
 
+cli.add_command(cnxml_to_html)
 cli.add_command(config_atom)
 cli.add_command(get)
 cli.add_command(list_environments)

--- a/nebu/tests/cli/test_cnxml_to_html.py
+++ b/nebu/tests/cli/test_cnxml_to_html.py
@@ -1,0 +1,63 @@
+import os
+from unittest import mock
+
+import pytest
+
+
+def get_files(directory, filename):
+    for root, dirs, files in os.walk(str(directory)):
+        if filename in files:
+            yield os.path.join(root, filename)
+
+
+@pytest.fixture
+def clear_files(request):
+    def _clear_files(directory, filename):
+        def cleanup():
+            for f in get_files(directory, filename):
+                os.unlink(f)
+
+        # make sure files are removed before tests
+        cleanup()
+
+        # make sure files are removed after tests
+        request.addfinalizer(cleanup)
+
+    return _clear_files
+
+
+@pytest.fixture
+def cnxml_to_full_html(request):
+    patcher = mock.patch('nebu.cli.cnxml_to_html.cnxml_to_full_html')
+    mock_function = patcher.start()
+    mock_function.return_value = '<html><body>transformed html</body></html>'
+    request.addfinalizer(patcher.stop)
+    return mock_function
+
+
+class TestCnxmlToHtmlCmd:
+    def test(self, datadir, invoker, clear_files, cnxml_to_full_html):
+        col_path = datadir / 'collection_no_changes'
+
+        # make sure index.cnxml.html doesn't exist
+        clear_files(col_path, 'index.cnxml.html')
+        index_cnxml_html = list(get_files(col_path, 'index.cnxml.html'))
+        assert index_cnxml_html == []
+
+        from nebu.cli.main import cli
+        args = ['cnxml-to-html', str(col_path)]
+        result = invoker(cli, args)
+        assert result.exit_code == 0
+
+        # make sure the number of index.cnxml.html is the same as index.cnxml
+        index_cnxml = list(get_files(col_path, 'index.cnxml'))
+        index_cnxml_html = list(get_files(col_path, 'index.cnxml.html'))
+        assert len(index_cnxml) == len(index_cnxml_html)
+        assert cnxml_to_full_html.call_count == len(index_cnxml)
+
+        # check that the index.cnxml.html is indeed transformed with the mocked
+        # cnxml_to_full_html function
+        for path in index_cnxml_html:
+            with open(path) as f:
+                content = f.read()
+            assert '<html><body>transformed html</body></html>' == content

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,5 +1,6 @@
 click
 cnx-litezip>=1.6.0
+cnx-transforms
 pip
 requests
 setuptools


### PR DESCRIPTION
Given a collection directory, use ~cnx-db~ cnx-transforms `cnxml_to_full_html` to
transform all the `index.cnxml` to `index.cnxml.html`.

---

I don't know how people feel about `cnxml2html` vs `cnxml-to-html` or something else.  I'm open to suggestions.

Depends on https://github.com/openstax/cnx-db/pull/174 and https://github.com/openstax/cnx-archive/pull/625

**NOTE:** Remove the last commit :skull_and_crossbones:  before merge.