### PR TITLE
Add "neb mathify" command

### DIFF
--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -12,6 +12,7 @@ from .atom import config_atom
 from .cnxml_to_html import cnxml_to_html
 from .get import get
 from .environment import list_environments
+from .mathify import mathify
 from .publish import publish
 from .validate import validate
 
@@ -100,5 +101,6 @@ cli.add_command(cnxml_to_html)
 cli.add_command(config_atom)
 cli.add_command(get)
 cli.add_command(list_environments)
+cli.add_command(mathify)
 cli.add_command(publish)
 cli.add_command(validate)

--- a/nebu/cli/mathify.py
+++ b/nebu/cli/mathify.py
@@ -1,0 +1,99 @@
+import os
+from pathlib import Path
+import re
+
+import click
+import docker
+
+from ..logger import logger
+from ._common import common_params
+
+
+IMAGE_TAG = 'openstax/mathify'
+REPO_URL = 'https://github.com/openstax/mathify.git'
+INPUT_FILE = 'collection.assembled.xhtml'
+OUTPUT_FILE = 'collection.mathified.xhtml'
+MOUNT_POINT = '/out'
+
+
+def get_input_file_path(collection_path):
+    for root, dirs, files in os.walk(collection_path):
+        if INPUT_FILE in files:
+            return Path(root, INPUT_FILE)
+
+
+@click.command()
+@common_params
+@click.option('-f', '--format', default='svg',
+              help='The format that math should transform to')
+@click.option('--build', is_flag=True,
+              help='Force build the baked-pdf image even if the image exists')
+@click.argument('collection_path')
+@click.pass_context
+def mathify(ctx, collection_path, build, format='svg'):
+    """Transform math in COLLECTION_PATH to svg or html"""
+    colpath = Path(collection_path)
+    input_file = get_input_file_path(collection_path)
+    if not input_file:
+        # invoke neb assemble if input file is not found
+        from .main import assemble  # TODO import from .assemble when ready
+        logger.info('Input file {} not found, running neb assemble...'.format(
+            INPUT_FILE))
+        ctx.invoke(assemble, collection_path=collection_path)
+        input_file = get_input_file_path(collection_path)
+    output_file = input_file.parent / OUTPUT_FILE
+    # If input_file is
+    # ./col12345_1.23.45/Introductory Statistics/collection.xhtml, then
+    # mounted_input_file will be
+    # /out/Introductory Statistics/collection.xhtml
+    # It replaces the top parent "col12345_1.23.45" with the mount point /out
+    mounted_input_file = MOUNT_POINT / input_file.relative_to(colpath)
+    mounted_output_file = mounted_input_file.parent / OUTPUT_FILE
+
+    client = docker.from_env()
+    try:
+        client.images.pull(IMAGE_TAG)
+    except docker.errors.ImageNotFound:
+        # the image might eventually be available on docker hub, but if it's
+        # not available, we can build the image ourselves
+        pass
+    images = client.images.list(IMAGE_TAG)
+    if not images or build:
+        logger.info('Building the {} image...'.format(IMAGE_TAG))
+        # docker build -t openstax/cnx-bakedpdf \
+        #    https://github.com/openstax/baked-pdf.git
+        image, build_logs = client.images.build(
+            path=REPO_URL, tag=IMAGE_TAG, rm=True)
+        for log in build_logs:
+            if 'stream' in log:
+                logger.debug(log['stream'])
+
+    # collection.mathified.html has resources pointing to the mathjax node
+    # module, which only exist in the container.  We need to copy out the files
+    # and change the resource urls.
+    mathify_command = "node typeset/start -i '{}' -o '{}' -f {}".format(
+        mounted_input_file, mounted_output_file, format)
+    copy_mathjax_resources = "cp -r node_modules/mathjax '{}'".format(
+        mounted_input_file.parent)
+    chmod_output = "chmod a+w '{}'".format(mounted_output_file)
+    command = ' && '.join([mathify_command, copy_mathjax_resources,
+                           chmod_output])
+    # docker run --rm openstax/cnx-bakedpdf
+    #    --mount type=bind,source=col12345_1.23.45,target=/out
+    #    /bin/bash -c \
+    #    "cp -r node_modules/mathjax /out/data/ && \
+    #     node typeset/start -i /out/data/collection.xhtml \
+    #                        -o /out/data/collection.mathified.xhtml \
+    #                        -f $MATH_FORMAT"
+    logger.debug('command: {}'.format(command))
+    run_logs = client.containers.run(
+        IMAGE_TAG, command='/bin/bash -c "{}"'.format(command), remove=True,
+        mounts=[
+            docker.types.Mount(target=MOUNT_POINT,
+                               source=str(colpath.absolute()), type='bind')])
+    logger.debug(run_logs.decode('utf-8'))
+    with output_file.open('r') as f:
+        content = f.read()
+    with output_file.open('w') as f:
+        f.write(re.sub('(file://)?/src/node_modules/', '', content))
+    logger.info('Math converted to {} in {}'.format(format, output_file))

--- a/nebu/tests/cli/test_mathify.py
+++ b/nebu/tests/cli/test_mathify.py
@@ -1,0 +1,130 @@
+from unittest import mock
+
+import pytest
+
+from nebu.cli.mathify import INPUT_FILE, OUTPUT_FILE, IMAGE_TAG, REPO_URL
+
+
+@pytest.fixture
+def mathify_cleanup(request, datadir):
+    def _mathify_cleanup(filenames=(INPUT_FILE, OUTPUT_FILE)):
+        def cleanup():
+            for filename in filenames:
+                output_file = datadir / filename
+                if output_file.is_file():
+                    output_file.unlink()
+
+        cleanup()
+        request.addfinalizer(cleanup)
+    return _mathify_cleanup
+
+
+def create_collection_xhtml(datadir):
+    with (datadir / INPUT_FILE).open('w') as out:
+        with (datadir / 'test_collection.xhtml').open('r') as in_:
+            out.write(in_.read())
+
+
+def create_mathified_xhtml(datadir):
+    def inner(*args, **kwargs):
+        with (datadir / OUTPUT_FILE).open('w') as out:
+            out.write('mathified collection xhtml')
+        return b''
+    return inner
+
+
+@pytest.fixture
+def mathify_docker_client(datadir):
+    patcher = mock.patch('nebu.cli.mathify.docker')
+    mock_docker = patcher.start()
+    client = mock_docker.from_env()
+    client.images.pull.return_value = ['<cnx-bakedpdf image>']
+    client.containers.run.side_effect = create_mathified_xhtml(
+        datadir)
+    yield client
+    patcher.stop()
+
+
+class TestMathifyCmd:
+    def test_w_collection_xhtml(self, datadir, invoker, mathify_cleanup,
+                                mathify_docker_client):
+        docker_client = mathify_docker_client
+        mathify_cleanup()
+        create_collection_xhtml(datadir)
+
+        from nebu.cli.main import cli
+        args = ['mathify', str(datadir)]
+        with mock.patch('nebu.cli.main.assemble') as assemble:
+            result = invoker(cli, args)
+            assert not assemble.called
+
+        assert docker_client.images.pull.called
+        assert not docker_client.images.build.called
+        assert docker_client.containers.run.called
+        (image_tag,), kwargs = docker_client.containers.run.call_args
+        assert image_tag == IMAGE_TAG
+        assert 'node typeset/start' in kwargs['command']
+
+        assert result.exit_code == 0
+        assert (datadir / OUTPUT_FILE).is_file()
+
+    def test_wo_collection_xhtml(self, datadir, invoker, mathify_cleanup,
+                                 mathify_docker_client):
+        docker_client = mathify_docker_client
+        mathify_cleanup()
+
+        from nebu.cli.main import cli
+        args = ['mathify', str(datadir)]
+        with mock.patch('nebu.cli.main.assemble') as assemble:
+            assemble.side_effect = lambda *args, **kwargs: \
+                create_collection_xhtml(datadir)
+            result = invoker(cli, args)
+            assert assemble.called
+            args, kwargs = assemble.call_args
+            assert kwargs['collection_path'] == str(datadir)
+
+        assert result.exit_code == 0
+        assert docker_client.containers.run.called
+
+    def test_image_not_found(self, datadir, invoker, mathify_cleanup,
+                             mathify_docker_client):
+        docker_client = mathify_docker_client
+        mathify_cleanup()
+        create_collection_xhtml(datadir)
+        docker_client.images.list.return_value = []
+        docker_client.images.build.side_effect = lambda *args, **kwargs: \
+            ('<image>', [{'stream': 'build log'}])
+
+        from nebu.cli.main import cli
+        args = ['mathify', str(datadir)]
+        result = invoker(cli, args, catch_exceptions=False)
+        assert result.exit_code == 0
+
+        assert docker_client.images.build.called
+        args, kwargs = docker_client.images.build.call_args
+        assert kwargs == {
+            'path': REPO_URL,
+            'tag': IMAGE_TAG,
+            'rm': True,
+        }
+
+    def test_build_flag(self, datadir, invoker, mathify_cleanup,
+                        mathify_docker_client):
+        docker_client = mathify_docker_client
+        mathify_cleanup()
+        create_collection_xhtml(datadir)
+        docker_client.images.build.side_effect = lambda *args, **kwargs: \
+            ('<image>', [{'stream': 'build log'}])
+
+        from nebu.cli.main import cli
+        args = ['mathify', '--build', str(datadir)]
+        result = invoker(cli, args, catch_exceptions=False)
+        assert result.exit_code == 0
+
+        assert docker_client.images.build.called
+        args, kwargs = docker_client.images.build.call_args
+        assert kwargs == {
+            'path': REPO_URL,
+            'tag': IMAGE_TAG,
+            'rm': True,
+        }

--- a/nebu/tests/data/test_collection.xhtml
+++ b/nebu/tests/data/test_collection.xhtml
@@ -1,0 +1,84 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Intro to Computational Engineering: Elec 220 Labs</title>
+    <meta content="" data-type="language" itemprop="inLanguage"/>
+
+    
+    <meta content="MathML" itemprop="accessibilityFeature"/>
+    <meta content="LaTeX" itemprop="accessibilityFeature"/>
+    <meta content="alternativeText" itemprop="accessibilityFeature"/>
+    <meta content="captions" itemprop="accessibilityFeature"/>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+
+
+    <meta content="" itemprop="dateCreated"/>
+    <meta content="" itemprop="dateModified"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Intro to Computational Engineering: Elec 220 Labs</h1>
+    </div>
+
+   <nav id="toc"><ol><li cnx-archive-uri="m42303"><a href="m42303.xhtml">Introduction to Quartus and Circuit Diagram Design</a></li><li cnx-archive-uri="m42302"><a href="m42302.xhtml">A Quartus Project from Start to Finish: 2 Bit Mux Tutorial</a></li><li cnx-archive-uri="m42304"><a href="m42304.xhtml">Lab 1-1: 4-Bit Mux and all NAND/NOR Mux</a></li><li cnx-archive-uri="m37151"><a href="m37151.xhtml">Lab 3-1 Basic MSP430 Assembly from Roots in LC-3</a></li><li cnx-archive-uri="m40643"><a href="m40643.xhtml">Lab 3-2 Digital Input and Output with the MSP430</a></li><li cnx-archive-uri="m37217"><a href="m37217.xhtml">Lab 4-1 Interrupt Driven Programming in MSP430 Assembly</a></li><li cnx-archive-uri="m40645"><a href="m40645.xhtml">Lab 4-2 Putting It All Together</a></li><li cnx-archive-uri="m37386"><a href="m37386.xhtml">Lab 5-1 C Language Programming through the ADC and the MSP430</a></li><li cnx-archive-uri="m40646"><a href="m40646.xhtml">Lab 5-2 Using C and the ADC for "Real World" Applications with the MSP430</a></li><li><span>Helpful General Information</span><ol><li cnx-archive-uri="m37152"><a href="m37152.xhtml">MSP430 LaunchPad Test Circuit Breadboarding Instructions</a></li><li cnx-archive-uri="m37154"><a href="m37154.xhtml">A Student to Student Intro to IDE Programming and CCS4</a></li></ol></li></ol></nav>
+  <div data-type="page" id="m42303"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introduction to Quartus and Circuit Diagram Design</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m42302"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">A Quartus Project from Start to Finish: 2 Bit Mux Tutorial</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m42304"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 1-1: 4-Bit Mux and all NAND/NOR Mux</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m37151"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 3-1 Basic MSP430 Assembly from Roots in LC-3</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m40643"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 3-2 Digital Input and Output with the MSP430</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m37217"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 4-1 Interrupt Driven Programming in MSP430 Assembly</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m40645"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 4-2 Putting It All Together</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m37386"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 5-1 C Language Programming through the ADC and the MSP430</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m40646"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Lab 5-2 Using C and the ADC for "Real World" Applications with the MSP430</h1>
+    </div>
+
+   
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Helpful General Information</h1>
+      <span data-type="binding" data-value="translucent"/>    </div>
+
+   <h1 data-type="document-title">Helpful General Information</h1><div data-type="page" id="m37152"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">MSP430 LaunchPad Test Circuit Breadboarding Instructions</h1>
+    </div>
+
+   
+  </div><div data-type="page" id="m37154"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">A Student to Student Intro to IDE Programming and CCS4</h1>
+    </div>
+
+   
+  </div></div></body>
+</html>

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -2,6 +2,7 @@ click
 cnx-epub>=0.17.0
 cnx-litezip>=1.6.0
 cnx-transforms
+docker
 pip
 requests
 setuptools


### PR DESCRIPTION
This branch is based on [fix_imgs_in_collhtml](https://github.com/openstax/nebuchadnezzar/tree/fix_imgs_in_collhtml) because it calls the `neb assemble` command if the input file `collection.xhtml` doesn't exist.

The "neb mathify" command uses docker to run [baked-pdf](https://github.com/openstax/baked-pdf) to transform the math in `collection.xhtml` to svg (by default) or html.  The output is in `collection.mathified.xhtml`.

~There are no tests yet but I'm working on them now.~  Have a look at the code and let me know what you think, thanks!