### PR TITLE
 Add the assemble command to produce a single-page-html file 

### DIFF
--- a/nebu/cli/assemble.py
+++ b/nebu/cli/assemble.py
@@ -1,0 +1,75 @@
+import shutil
+from pathlib import Path
+
+import click
+from cnxepub.formatters import (
+    HTMLFormatter,
+    SingleHTMLFormatter,
+)
+from cnxepub.models import flatten_to_documents
+
+from ._common import common_params, logger
+from ..models.binder import Binder
+from ..models.utils import scan_for_id_mapping
+from ..utils import relative_path
+
+
+def produce_collection_xhtml(binder, output_dir):
+    collection_xhtml = output_dir / 'collection.assembled.xhtml'
+    with collection_xhtml.open('wb') as fb:
+        fb.write(bytes(SingleHTMLFormatter(binder)))
+
+    return collection_xhtml
+
+
+def provide_supporting_files(input_dir, output_dir, binder):
+    documents = {doc.id: doc for doc in flatten_to_documents(binder)}
+    for id, filepath in scan_for_id_mapping(input_dir).items():
+        (output_dir / id).symlink_to(
+            relative_path(filepath.parent, output_dir)
+        )
+        with (output_dir / '{}.xhtml'.format(id)).open('wb') as fb:
+            fb.write(bytes(HTMLFormatter(documents[id])))
+
+
+@click.command(name='assemble')
+@common_params
+@click.argument('input-dir', type=click.Path(exists=True))
+@click.argument('output-dir', type=click.Path())
+@click.pass_context
+def assemble(ctx, input_dir, output_dir):
+    """Assembles litezip structure data into a single-page-html file.
+
+    This also stores the intermediary results alongside the resulting
+    assembled single-page-html.
+
+    """
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+
+    if output_dir.exists():
+        confirm_msg = (
+            "This will remove '{}', continue?"
+            .format(str(output_dir))
+        )
+        click.confirm(confirm_msg, abort=True, err=True)
+        shutil.rmtree(str(output_dir))
+    output_dir.mkdir()
+
+    collection_xml = input_dir / 'collection.xml'
+    binder = Binder.from_collection_xml(collection_xml)
+
+    # Write the collection.xml symlink to the output directory
+    output_collection_xml = (output_dir / 'collection.xml')
+    output_collection_xml.symlink_to(
+        relative_path(collection_xml, output_dir)
+    )
+
+    # Write the binder out as a single-page-html
+    collection_xhtml = produce_collection_xhtml(binder, output_dir)
+    logger.debug('Wrote: {}'.format(str(collection_xhtml.resolve())))
+
+    # Write the symbolic links for modules to the output directory
+    provide_supporting_files(input_dir, output_dir, binder)
+
+    return 0

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -7,6 +7,7 @@ import re
 from nebu import __version__
 from ..config import prepare
 
+from .assemble import assemble
 from .atom import config_atom
 from .cnxml_to_html import cnxml_to_html
 from .get import get
@@ -94,6 +95,7 @@ def cli(ctx):
     ctx.obj = env
 
 
+cli.add_command(assemble)
 cli.add_command(cnxml_to_html)
 cli.add_command(config_atom)
 cli.add_command(get)

--- a/nebu/tests/cli/test_assemble.py
+++ b/nebu/tests/cli/test_assemble.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+
+from nebu.cli import assemble
+from nebu.cli.main import cli
+
+
+@pytest.fixture
+def src_data(datadir):
+    return datadir / 'collection_for_bakedpdf_workflow'
+
+
+@pytest.fixture
+def result_data(datadir):
+    return datadir / 'assembled_collection_for_bakedpdf_workflow'
+
+
+class FauxSingleHTMLFormatter(object):
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+
+    def __bytes__(self):
+        return b'faux'
+
+
+class TestAssembleCmd:
+
+    @pytest.fixture(autouse=True)
+    def stub_SingleHTMLFormatter(self, monkeypatch):
+        self.SingleHTMLFormatter = FauxSingleHTMLFormatter
+        monkeypatch.setattr(
+            assemble,
+            'SingleHTMLFormatter',
+            self.SingleHTMLFormatter,
+        )
+
+    def test(self, tmp_path, src_data, result_data, invoker):
+        output_dir = tmp_path / 'build'
+
+        args = [
+            'assemble',  # (target)
+            str(src_data), str(output_dir),
+        ]
+        result = invoker(cli, args)
+
+        output_file = (output_dir / 'collection.assembled.xhtml').resolve()
+
+        # Verify the invocation output
+        assert result.exit_code == 0, result.output
+
+        # Verify the file output
+        with output_file.open('rb') as ofb:
+            assert ofb.read().decode() == 'faux'
+
+        # Verify symlink to collection.xml
+        collection_xml = (output_dir / 'collection.xml')
+        assert collection_xml.is_symlink()
+        # note, Path wraps this because pathlib2.Path is used
+        # see also `_flavour` property on the object, which is used in
+        # equality comparison.
+        expected_filepath = (src_data / 'collection.xml').resolve()
+        assert Path(str(collection_xml.resolve())) == expected_filepath
+
+        # Verify symlink to original data directories
+        m46882_dir = (output_dir / 'm46882')
+        assert m46882_dir.is_symlink()
+        expected_dir = (src_data / 'm46882').resolve()
+        assert Path(str(m46882_dir.resolve())) == expected_dir
+
+    def test_output_dir_exists_proceed(self, tmp_path, src_data, result_data,
+                                       invoker):
+        output_dir = tmp_path / 'build'
+        output_dir.mkdir()
+
+        from nebu.cli.main import cli
+        args = [
+            'assemble',  # (target)
+            str(src_data), str(output_dir),
+        ]
+        result = invoker(cli, args, input='y\n')  # 'y', proceed with removal
+
+        # Verify the invocation output
+        assert result.exit_code == 0, result.output
+
+    def test_output_dir_exists_abort(self, tmp_path, src_data, result_data,
+                                     invoker):
+        output_dir = tmp_path / 'build'
+        output_dir.mkdir()
+
+        from nebu.cli.main import cli
+        args = [
+            'assemble',  # (target)
+            str(src_data), str(output_dir),
+        ]
+        result = invoker(cli, args, input='\n')  # accept default: 'N'
+
+        # Verify the invocation output
+        assert result.exit_code == 1, result.output
+        assert 'Aborted!' in result.output

--- a/nebu/tests/data/assembled_collection_for_bakedpdf_workflow/collection.assembled.xhtml
+++ b/nebu/tests/data/assembled_collection_for_bakedpdf_workflow/collection.assembled.xhtml
@@ -1,0 +1,353 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Introductory Statistics</title>
+    <meta content="en" data-type="language" itemprop="inLanguage"/>
+
+    
+    <meta content="MathML" itemprop="accessibilityFeature"/>
+    <meta content="LaTeX" itemprop="accessibilityFeature"/>
+    <meta content="alternativeText" itemprop="accessibilityFeature"/>
+    <meta content="captions" itemprop="accessibilityFeature"/>
+    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+
+
+    <meta content="2013-07-18T19:30:26-05:00" itemprop="dateCreated"/>
+    <meta content="2019-02-22T14:15:14.840187-06:00" itemprop="dateModified"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introductory Statistics</h1>
+      <span data-type="cnx-archive-uri" data-value="col11562@1.23"/>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="publishers">
+        Published By:
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+            </span>,             <span data-type="publisher" id="publisher-2" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="cnxstats" itemprop="url">cnxstats</a>
+            </span>      </div>
+      <div class="print-style">
+        Print style:
+        <span data-type="print-style">statistics</span>
+      </div>
+      <div class="permissions">
+        <p class="copyright">
+          Copyright:
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+              </span>        </p>
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC BY</a>
+        </p>
+      </div><div data-type="subject" itemprop="about">Mathematics and Statistics</div>    </div>
+
+   <nav id="toc"><ol><li cnx-archive-uri="m47830@1.17"><a href="m47830@1.17.xhtml">Preface</a></li><li><span>Sampling and Data</span><ol><li cnx-archive-uri="m46913@1.13"><a href="m46913@1.13.xhtml">Introduction</a></li><li cnx-archive-uri="m46909@1.12"><a href="m46909@1.12.xhtml">Definitions of Statistics, Probability, and Key Terms</a></li><li cnx-archive-uri="m46885@1.21"><a href="m46885@1.21.xhtml">Data, Sampling, and Variation in Data and Sampling</a></li><li cnx-archive-uri="m46882@1.17"><a href="m46882@1.17.xhtml">Frequency, Frequency Tables, and Levels of Measurement</a></li><li cnx-archive-uri="m46919@1.13"><a href="m46919@1.13.xhtml">Experimental Design and Ethics</a></li></ol></li><li><span>Descriptive Statistics</span><ol><li cnx-archive-uri="m46925@1.7"><a href="m46925@1.7.xhtml">Introduction</a></li><li cnx-archive-uri="m46934@1.10"><a href="m46934@1.10.xhtml">Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs</a></li></ol></li><li cnx-archive-uri="m47864@1.17"><a href="m47864@1.17.xhtml">Review Exercises (Ch 3-13)</a></li><li cnx-archive-uri="m47865@1.16"><a href="m47865@1.16.xhtml">Practice Tests (1-4) and Final Exams</a></li><li cnx-archive-uri="m47873@1.9"><a href="m47873@1.9.xhtml">Data Sets</a></li></ol></nav>
+  <div data-type="page" id="m47830@1.17"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Preface</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Preface.
+      </p>
+    </div>
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Sampling and Data</h1>
+      <span data-type="binding" data-value="translucent"/>    </div>
+
+   <h1 data-type="document-title">Sampling and Data</h1><div class="introduction" data-cnxml-to-html-ver="1.3.3" data-type="page" id="m46913"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introduction to Statistics</h1>
+      <span data-type="cnx-archive-uri" data-value="m46913@1.13"/>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="publishers">
+        Published By:
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+            </span>,             <span data-type="publisher" id="publisher-2" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="cnxstats" itemprop="url">cnxstats</a>
+            </span>      </div>
+      <div class="permissions">
+        <p class="copyright">
+          Copyright:
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="OSCRiceUniversity" itemprop="url">OSCRiceUniversity</a>
+              </span>        </p>
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">CC BY</a>
+        </p>
+      </div><div data-type="keyword" itemprop="keywords">average</div><div data-type="keyword" itemprop="keywords">bar graph</div><div data-type="subject" itemprop="about">Mathematics and Statistics</div>
+      <div data-type="resources">
+        <ul>
+<li><a href="CNX_Stats_C01_COs.jpg">CNX_Stats_C01_COs.jpg</a></li><li><a href="CNX_Stats_C01_CO.jpg">CNX_Stats_C01_CO.jpg</a></li>        </ul>
+      </div>    </div>
+
+   <div data-type="document-title" id="auto_m46913_95271">Introduction to Statistics</div><cnx-pi data-type="cnx.flag.introduction">
+        class="introduction"
+      </cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="summary" title="Chapter Review"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="formula-review" title="Formula Review"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="practice" title="Practice"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="bring-together-exercises" title="Bringing It Together : Practice"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="free-response" title="Homework"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="bring-together-homework" title="Bringing It Together : Homework"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="references" title="References"</cnx-pi>
+
+
+
+
+
+<figure class="splash" id="auto_m46913_fig-ch01_00_01"><span data-alt="This photo shows a large open news room with enough space to seat about 200 employees." data-type="media" id="auto_m46913_fs-id2354221">
+<img alt="This photo shows a large open news room with enough space to seat about 200 employees." data-media-type="image/jpg" id="auto_m46913_13468" src="m46913/CNX_Stats_C01_COs.jpg" width="600"/>
+</span>
+</figure>
+
+
+
+<p id="auto_m46913_eip-1000">Since you will undoubtedly be given statistical information at some point in your life, you need to know some techniques for analyzing the information thoughtfully. Think about buying a house or managing a budget. Think about your chosen profession.   The fields of economics, business, psychology, education, biology, law, computer science, police science, and early childhood development require at least one course in statistics.</p>
+
+
+  </div><div data-cnxml-to-html-ver="1.3.3" data-type="page" id="m46909"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Definitions of Statistics, Probability, and Key Terms</h1>
+      <span data-type="cnx-archive-uri" data-value="m46909@1.12"/>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="publishers">
+        Published By:
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+            </span>,             <span data-type="publisher" id="publisher-2" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="cnxstats" itemprop="url">cnxstats</a>
+            </span>      </div>
+      <div class="permissions">
+        <p class="copyright">
+          Copyright:
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="OSCRiceUniversity" itemprop="url">OSCRiceUniversity</a>
+              </span>        </p>
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC BY</a>
+        </p>
+      </div><div data-type="keyword" itemprop="keywords">average</div><div data-type="keyword" itemprop="keywords">categorical variable</div><div data-type="subject" itemprop="about">Mathematics and Statistics</div>
+      <div data-type="resources">
+        <ul>
+<li><a href="fig-ch01_02_01n.png">fig-ch01_02_01n.png</a></li><li><a href="m16020_DotPlot_download.pdf">m16020_DotPlot_download.pdf</a></li><li><a href="m16020_DotPlot_description.html">m16020_DotPlot_description.html</a></li><li><a href="Prev_m16020_DotPlot.png">Prev_m16020_DotPlot.png</a></li>        </ul>
+      </div>    </div>
+
+   <div data-type="document-title" id="auto_m46909_30588">Definitions of Statistics, Probability, and Key Terms</div>
+
+<figure id="auto_m46909_eip-idp25549888"><span data-alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." data-longdesc="m16020_DotPlot_description.html" data-type="media" id="auto_m46909_id44761709a">
+<img alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." data-longdesc="m16020_DotPlot_description.html" data-media-type="image/png" id="auto_m46909_14964" src="m46909/fig-ch01_02_01n.png" width="380">
+</img></span>
+</figure>
+
+<p id="auto_m46909_id10326643">Does your dot plot look the same as or different from the example? Why? If you did the same example in an English class with the same number of students, do you think the results would be the same? Why or why not?</p>
+
+<div data-type="glossary" id="auto_m46909_31800"><h3 data-type="glossary-title">Glossary</h3>
+<dl id="auto_m46909_average">
+<dt id="auto_m46909_67847">Average</dt>
+<dd id="auto_m46909_id16316921">also called mean; a number that describes the central tendency of the data</dd>
+</dl>
+</div>
+  </div><div data-type="page" id="m46885@1.21"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Data, Sampling, and Variation in Data and Sampling</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Data, Sampling, and Variation in Data and Sampling.
+      </p>
+    </div>
+  </div><div data-cnxml-to-html-ver="1.3.3" data-type="page" id="m46882"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Frequency, Frequency Tables, and Levels of Measurement</h1>
+      <span data-type="cnx-archive-uri" data-value="m46882@1.17"/>
+
+      <div class="authors">
+        By:
+<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+            <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="publishers">
+        Published By:
+            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="OpenStaxCollege" itemprop="url">OpenStaxCollege</a>
+            </span>,             <span data-type="publisher" id="publisher-2" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
+              <a data-type="cnx-id" href="cnxstats" itemprop="url">cnxstats</a>
+            </span>      </div>
+      <div class="permissions">
+        <p class="copyright">
+          Copyright:
+              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
+                <a data-type="cnx-id" href="OSCRiceUniversity" itemprop="url">OSCRiceUniversity</a>
+              </span>        </p>
+        <p class="license">
+          Licensed:
+          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC BY</a>
+        </p>
+      </div><div data-type="keyword" itemprop="keywords">cumulative relative frequency</div><div data-type="keyword" itemprop="keywords">frequency</div><div data-type="subject" itemprop="about">Mathematics and Statistics</div>
+      <div data-type="resources">
+        <ul>
+<li><a href="CNX_Stats_C01_M10_001.jpg">CNX_Stats_C01_M10_001.jpg</a></li><li><a href="CNX_Stats_C01_M10_002.jpg">CNX_Stats_C01_M10_002.jpg</a></li><li><a href="CNX_Stats_C01_M10_003.jpg">CNX_Stats_C01_M10_003.jpg</a></li>        </ul>
+      </div>    </div>
+
+   <div data-type="document-title" id="auto_m46882_26056">Frequency, Frequency Tables, and Levels of Measurement</div>
+  
+  <p id="auto_m46882_fs-idp5986864">Once you have a set of data, you will need to organize it so that you can analyze how frequently each datum occurs in the set. However, when calculating the frequency, you may need to round your answers so that they are as precise as possible.</p>
+  
+  <figure data-orient="horizontal" id="auto_m46882_eip-idp25576880"><span data-alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1." data-type="media" id="auto_m46882_fs-idm20141232">
+    <img alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1." data-media-type="image/jpg" id="auto_m46882_24576" src="m46882/CNX_Stats_C01_M10_003.jpg"/>
+  </span>
+  </figure>
+  
+  <figure id="auto_m46882_eip-idp53333999">
+    <span data-alt="Links to a non-existent resource" data-type="media" id="auto_m46882_id9955bb01a">
+      <img alt="Links to a non-existent resource" data-media-type="image/png" id="auto_m46882_4971" src="foobar.png"/>
+    </span>
+  </figure>
+  
+  <p id="auto_m46882_linkexample">
+    There are many ways to grill
+    <a href="/m10275@2.1">a good 
+    steak</a>. My favorite can be found
+    <a href="http://en.wikibooks.org/" target="_window">on Wikibooks</a>.
+  </p>
+
+
+
+<div data-type="glossary" id="auto_m46882_78423"><h3 data-type="glossary-title">Glossary</h3>
+
+  <dl id="auto_m46882_cumrelfreq">
+    <dt id="auto_m46882_61951">Cumulative Relative Frequency</dt>
+    <dd id="auto_m46882_id19883082">
+      The term applies to an ordered set of observations from smallest to largest. The cumulative relative frequency is the sum of the relative frequencies for all values that are less than or equal to the given value.
+    </dd>
+  </dl>
+
+
+  <dl id="auto_m46882_freq">
+    <dt id="auto_m46882_88522">Frequency</dt>
+    <dd id="auto_m46882_id19849552">
+   the number of times a value of the data occurs</dd>
+  </dl>
+
+</div>
+  </div><div data-type="page" id="m46919@1.13"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Experimental Design and Ethics</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Experimental Design and Ethics.
+      </p>
+    </div>
+  </div></div><div data-type="chapter"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Descriptive Statistics</h1>
+      <span data-type="binding" data-value="translucent"/>    </div>
+
+   <h1 data-type="document-title">Descriptive Statistics</h1><div data-type="page" id="m46925@1.7"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Introduction</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Introduction.
+      </p>
+    </div>
+  </div><div data-type="page" id="m46934@1.10"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs.
+      </p>
+    </div>
+  </div></div><div data-type="page" id="m47864@1.17"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Review Exercises (Ch 3-13)</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Review Exercises (Ch 3-13).
+      </p>
+    </div>
+  </div><div data-type="page" id="m47865@1.16"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Practice Tests (1-4) and Final Exams</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Practice Tests (1-4) and Final Exams.
+      </p>
+    </div>
+  </div><div data-type="page" id="m47873@1.9"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Data Sets</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Data Sets.
+      </p>
+    </div>
+  </div></body>
+</html>

--- a/nebu/tests/data/assembled_collection_for_bakedpdf_workflow/rebuild.py
+++ b/nebu/tests/data/assembled_collection_for_bakedpdf_workflow/rebuild.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 from cnxepub import formatters
+from nebu.models.binder import Binder
 from nebu.models.document import Document
 from nebu.tests.models.test_document import mock_reference_resolver
 from nebu.utils import relative_path
@@ -12,6 +13,7 @@ output_dir = Path('.')
 
 
 def main():
+    # Transform the modules from cnxml to html
     for id in ('m46882', 'm46909', 'm46913'):
         filepath = input_dir / id / 'index.cnxml'
         doc = Document.from_index_cnxml(filepath, mock_reference_resolver)
@@ -27,6 +29,11 @@ def main():
         link_to_source_dir.unlink()
         source_dir = input_dir / id
         link_to_source_dir.symlink_to(relative_path(source_dir, output_dir))
+
+    # Create the single-page-html
+    binder = Binder.from_collection_xml(input_dir / 'collection.xml')
+    with (output_dir / 'collection.assembled.xhtml').open('wb') as fb:
+        fb.write(bytes(formatters.SingleHTMLFormatter(binder)))
 
 
 if __name__ == '__main__':

--- a/nebu/tests/data/assembled_collection_for_bakedpdf_workflow/rebuild.py
+++ b/nebu/tests/data/assembled_collection_for_bakedpdf_workflow/rebuild.py
@@ -1,17 +1,14 @@
 """ This script rebuilds the contents of this directory """
-import os.path
 from pathlib import Path
 
 from cnxepub import formatters
 from nebu.models.document import Document
 from nebu.tests.models.test_document import mock_reference_resolver
+from nebu.utils import relative_path
+
 
 input_dir = Path('../collection_for_bakedpdf_workflow')
 output_dir = Path('.')
-
-
-def relative_path(path, start=Path('.')):
-    return Path(os.path.relpath(str(path.resolve()), start=str(start)))
 
 
 def main():

--- a/nebu/tests/test_utils.py
+++ b/nebu/tests/test_utils.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+from nebu.utils import relative_path
+
+
+def _mkdir(p):
+    try:
+        p.mkdir()
+    except FileNotFoundError:
+        _mkdir(p.parent)
+        p.mkdir()
+
+
+@pytest.fixture
+def test_dirs(tmp_path):
+    dirs = [
+        tmp_path / 'foo' / 'aaa' / '000',
+        tmp_path / 'bar' / 'bbb' / '111',
+        tmp_path / 'baz' / 'ccc' / '222',
+    ]
+    for d in dirs:
+        _mkdir(d)
+    return dirs
+
+
+@pytest.mark.usefixtures('test_dirs')
+class TestRelativePath(object):
+    # These test ``p`` relative to ``s``
+
+    def test_sibling(self, tmp_path):
+        p = tmp_path / 'foo'
+        s = tmp_path / 'bar'
+        result = relative_path(p, s)
+        assert result == Path('../foo')
+
+    def test_child(self, tmp_path):
+        p = tmp_path / 'baz' / 'bbb' / '111'
+        s = tmp_path
+        result = relative_path(p, s)
+        assert result == Path('baz/bbb/111')
+
+    def test_distant_siblings(self, tmp_path):
+        p = tmp_path / 'foo' / 'aaa' / '000'
+        s = tmp_path / 'bar' / 'bbb' / '111'
+        result = relative_path(p, s)
+        assert result == Path('../../../foo/aaa/000')

--- a/nebu/utils.py
+++ b/nebu/utils.py
@@ -1,0 +1,25 @@
+import os.path
+from pathlib import Path
+
+
+def relative_path(path, start=Path('.')):
+    """This is a :class:`pathlib.Path` compatible way of building relative
+    paths. ``Path.relative_to()`` does exist, but does not correctly apply
+    sibling descendent relationships (aka ``../``). ``os.path.relpath`` does
+    what is wanted, so we use it, but with ``pathlib`` objects.
+
+    Note, this function requires ``path`` and ``start`` to be resolvable.
+    Or in other words, they must exist, so that we can obtain an absolute
+    path. Directly use ``os.path.relpath`` if this is a problem.
+
+    :param path: the path to make relative
+    :type path: :class:`pathlib.Path`
+    :param start: starting location to make the given ``path`` relative to
+    :type start: :class:`pathlib.Path`
+    :return: relative path
+    :rtype: :class:`pathlib.Path`
+
+    """
+    p = str(path.resolve())
+    s = str(start.resolve())
+    return Path(os.path.relpath(p, start=s))

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 pretend
-pytest
+pytest>=4
 pytest-cov
 pytest-runner
 requests-mock


### PR DESCRIPTION
### Description

This produces a single-page-html file from a litezip structured
set of data that is first converted from cnxml to html and then
assembled into a single html file.

### Usage

The interface for this looks like the following:
```sh
$ neb get -r prod col11562 1.23.21
...
$ neb assemble --help
$ neb assemble col11562_1.23.21 workspace
```
Where `col11562_1.23.21` is the directory containing the acquired data from `neb get ...` and `build` is the user defined output directory for the assembled results.

I'm honestly not sure what's wanted as far as the output from the command goes. So the minimum has been put in. Rather than waste time testing for command output that is likely to change anyway, I'll defer to providing as little output as possible until *future feedback* is given to define how the command's output should look.

### Results structure

```
$ tree
├── cocina
│   ├── collection.assembled.xhtml
│   ├── collection.xml -> ../col11562_1.23.21/collection.xml
│   ├── m46882 -> ../col11562_1.23.21/m46882
│   ├── m46882.xhtml
│   ├── m46885 -> ../col11562_1.23.21/m46885
│   ├── m46885.xhtml
...
│   ├── m50285 -> ../col11562_1.23.21/m50285
│   ├── m50285.xhtml
│   ├── m50287 -> ../col11562_1.23.21/m50287
│   ├── m50287.xhtml
│   ├── m50288 -> ../col11562_1.23.21/m50288
│   └── m50288.xhtml
└── col11562_1.23.21
    ├── collection.xml
    ├── m46882
    │   ├── CNX_Stats_C01_M10_001.jpg
    │   ├── CNX_Stats_C01_M10_002.jpg
    │   ├── CNX_Stats_C01_M10_003.jpg
    │   └── index.cnxml
    ├── m46885
    │   ├── CNX_Stats_C01_M05_001.jpg
    │   ├── CNX_Stats_C01_M05_002.jpg
    │   ├── CNX_Stats_C01_M05_002.png
    │   ├── CNX_Stats_C01_Screenshots.jpg
    │   ├── fig-ch01_patchfile_01.jpg
    │   ├── fig-ch01_patchfile_02.jpg
    │   ├── fig-ch01_patchfile_03.jpg
    │   ├── fig-ch01_patchfile_04.jpg
    │   ├── fig-ch01_patchfile_05.jpg
    │   ├── fig-ch01_patchfile_06.jpg
    │   ├── fig-ch01_patchfile_07.jpg
    │   ├── fig-ch01_patchfile_08.jpg
    │   ├── fig-ch01_patchfile_09.jpg
    │   └── index.cnxml
...
    ├── m50285
    │   ├── fig-ch12_15_01.png
    │   └── index.cnxml
    ├── m50287
    │   ├── fig-ch12_15_01.png
    │   ├── fig-ch12_16_01.png
    │   └── index.cnxml
    └── m50288
        └── index.cnxml

206 directories, 998 files
```
Where `m46882 -> ../col11562_1.23.21/m46882` for instance represents a shortcut (aka symbolic link ) to the source directory. This is how an images for instance is referenced in the content as `m46882/CNX_Stats_C01_M10_003.jpg` and actually link to the source's images, which allows the browser to display it.