### PR TITLE
Add "neb bake" command to bake a mathified book html

### DIFF
--- a/nebu/cli/bake.py
+++ b/nebu/cli/bake.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+
+import click
+import cnxeasybake
+from lxml import etree
+
+from ..logger import logger
+from ._common import common_params
+
+
+INPUT_FILE = 'collection.mathified.xhtml'
+OUTPUT_FILE = 'collection.baked.xhtml'
+
+
+def get_input_file_path(collection_path):
+    for root, dirs, files in os.walk(collection_path):
+        if INPUT_FILE in files:
+            return Path(root, INPUT_FILE)
+
+
+@click.command()
+@common_params
+@click.option('-r', '--recipe', type=click.Path(exists=True, file_okay=True),
+              help='Path to a CSS3 ruleset stylesheet recipe')
+@click.option('-s', '--style', type=click.Path(exists=True, file_okay=True),
+              help='Path to a CSS file to include in the html')
+@click.option('-i', '--input-file',
+              type=click.Path(exists=True, file_okay=True),
+              help='Location of the input file')
+@click.argument('collection_path')
+@click.pass_context
+def bake(ctx, collection_path, recipe, style, input_file):
+    """Use cnx-easybake to bake the collection html"""
+    if input_file:
+        input_file = Path(input_file)
+    else:
+        input_file = get_input_file_path(collection_path)
+    if not input_file or not input_file.is_file():
+        raise ValueError('Input file {} not found or is not a file.'.format(
+            input_file))
+    output_file = input_file.parent / OUTPUT_FILE
+
+    oven = cnxeasybake.Oven(recipe)
+    with input_file.open('r') as f:
+        html_doc = etree.parse(f)
+    oven.bake(html_doc)
+    if style:
+        head = html_doc.xpath('/x:html/x:head', namespaces={
+            'x': 'http://www.w3.org/1999/xhtml'})
+        if head:
+            etree.SubElement(head[0], 'link', {
+                'rel': 'stylesheet',
+                'type': 'text/css',
+                'href': str(Path(style).absolute()),
+            })
+    with output_file.open('wb') as f:
+        f.write(etree.tostring(html_doc))
+    logger.info('Baked HTML in {}'.format(output_file))

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -9,6 +9,7 @@ from ..config import prepare
 
 from .assemble import assemble
 from .atom import config_atom
+from .bake import bake
 from .get import get
 from .environment import list_environments
 from .mathify import mathify
@@ -96,6 +97,7 @@ def cli(ctx):
 
 
 cli.add_command(assemble)
+cli.add_command(bake)
 cli.add_command(config_atom)
 cli.add_command(get)
 cli.add_command(list_environments)

--- a/nebu/tests/cli/test_bake.py
+++ b/nebu/tests/cli/test_bake.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+import tempfile
+from unittest import mock
+
+from lxml import etree
+import pytest
+
+from nebu.cli.bake import INPUT_FILE, OUTPUT_FILE
+
+
+@pytest.fixture
+def bake_cleanup(request, datadir):
+    def cleanup():
+        for filename in (INPUT_FILE, OUTPUT_FILE):
+            output_file = datadir / filename
+            if output_file.is_file():
+                output_file.unlink()
+    cleanup()
+    request.addfinalizer(cleanup)
+
+
+@pytest.fixture
+def easybake_oven():
+    patcher = mock.patch('nebu.cli.bake.cnxeasybake')
+    easybake = patcher.start()
+    yield easybake.Oven
+    patcher.stop()
+
+
+def create_collection_mathified_xhtml(datadir, filename=INPUT_FILE):
+    with (datadir / filename).open('w') as f:
+        f.write('<html xmlns="http://www.w3.org/1999/xhtml"><head></head>'
+                '<body></body></html>')
+
+
+class TestBakeCmd:
+    def test_wo_mathified_xhtml(self, datadir, invoker, bake_cleanup,
+                                easybake_oven):
+        from nebu.cli.main import cli
+        args = ['bake', str(datadir)]
+        result = invoker(cli, args)
+
+        assert result.exit_code == 1
+        assert str(result.exception) == \
+            'Input file None not found or is not a file.'
+        assert not easybake_oven.called
+        assert not (datadir / OUTPUT_FILE).exists()
+
+    def test_input_file_directory(self, datadir, invoker, bake_cleanup):
+        from nebu.cli.main import cli
+        args = ['bake', '-i', str(datadir), str(datadir)]
+        result = invoker(cli, args)
+
+        assert result.exit_code == 1
+        assert str(result.exception) == \
+            'Input file {} not found or is not a file.'.format(datadir)
+
+    def test_input_file(self, datadir, invoker, bake_cleanup, easybake_oven):
+        create_collection_mathified_xhtml(datadir, filename='my_input.xhtml')
+        from nebu.cli.main import cli
+        args = ['bake', '-i', str(datadir / 'my_input.xhtml'), str(datadir)]
+        result = invoker(cli, args)
+
+        assert result.exit_code == 0
+
+    def test_w_mathified_xhtml(self, datadir, invoker, bake_cleanup,
+                               easybake_oven):
+        create_collection_mathified_xhtml(datadir)
+        from nebu.cli.main import cli
+        with tempfile.NamedTemporaryFile() as f:
+            args = ['bake', '-r', f.name, str(datadir)]
+            result = invoker(cli, args)
+
+        assert result.exit_code == 0
+        easybake_oven.assert_called_with(f.name)
+        oven = easybake_oven(f.name)
+        assert oven.bake.called
+        assert etree.tostring(oven.bake.call_args[0][0]) == \
+            b'<html xmlns="http://www.w3.org/1999/xhtml"><head/><body/></html>'
+        assert (datadir / OUTPUT_FILE).exists()
+
+    def test_w_style(self, datadir, invoker, bake_cleanup, easybake_oven):
+        create_collection_mathified_xhtml(datadir)
+        from nebu.cli.main import cli
+        with tempfile.NamedTemporaryFile() as f:
+            with tempfile.NamedTemporaryFile() as g:
+                style = g.name
+                args = ['bake', '-r', f.name, '-s', style, str(datadir)]
+                result = invoker(cli, args)
+
+        assert result.exit_code == 0
+        assert (datadir / OUTPUT_FILE).exists()
+        with (datadir / OUTPUT_FILE).open('r') as f:
+            root = etree.parse(f)
+            link = root.xpath('/x:html/x:head/x:link', namespaces={
+                'x': 'http://www.w3.org/1999/xhtml'})[0]
+            assert link.attrib['href'] == str(Path(style).absolute())
+            assert link.attrib['type'] == 'text/css'
+            assert link.attrib['rel'] == 'stylesheet'

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,5 +1,6 @@
 click
 cnxml>=3.0.1
+cnx-easybake>=1.2.1
 cnx-epub>=0.18.0
 cnx-litezip>=1.6.0
 cnx-transforms>=1.1.0


### PR DESCRIPTION
Use cnx-easybake to collate a book by using a css3 recipe file.
`neb bake` also accepts a `--style` option so a css file can be added to
the baked html.

---

Waiting on mathify #130 and assemble #136.