### PR TITLE
Fix to transform the summary text during assembly

### DIFF
--- a/nebu/models/utils.py
+++ b/nebu/models/utils.py
@@ -1,6 +1,8 @@
 from copy import copy
 
+from cnxepub.utils import squash_xml_to_text
 from cnxml.parse import parse_metadata as parse_cnxml_metadata
+from cnxtransforms import cnxml_abstract_to_html
 from lxml import etree
 
 
@@ -63,7 +65,10 @@ def convert_to_model_compat_metadata(metadata):
 
     md['summary'] = md.pop('abstract')
     md['summary'] = md['summary'] and md['summary'] or None
-
+    if md['summary'] is not None:
+        s = cnxml_abstract_to_html(md['summary'])
+        s = etree.fromstring(s)
+        md['summary'] = squash_xml_to_text(s, remove_namespaces=True)
     return md
 
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,8 +1,8 @@
 click
 cnxml>=3.0.1
-cnx-epub>=0.17.0
+cnx-epub>=0.18.0
 cnx-litezip>=1.6.0
-cnx-transforms
+cnx-transforms>=1.1.0
 docker
 pip
 requests


### PR DESCRIPTION
We were not previously transforming the summary text during model
instantiation. This was causing issues with some content that had math in the
summary. The problem was specifically related to the `<m:...` namespace not
being defined. In terms of HTML this isn't an issue, but the problem was
none of that content was being transformed to HTML, not just the math.

This pulls in an updated cnx-transforms and cnx-epub to complete this work.
The versions have been constrained because version prior to that do not
contain the necessary imports.

This addresses openstax/cnx#290. I've been able to work through that case
without issues. I'd call it resolved.