### PR TITLE
Fix to always default to using the non-collated version

### DIFF
--- a/nebu/cli/get.py
+++ b/nebu/cli/get.py
@@ -40,7 +40,7 @@ def get(ctx, env, col_id, col_version, output_dir, book_tree, get_resources):
 
     col_hash = '{}/{}'.format(col_id, col_version)
     # Fetch metadata
-    url = '{}/content/{}'.format(base_url, col_hash)
+    url = '{}/content/{}?as_collated=False'.format(base_url, col_hash)
 
     # Create a request session with retries if there's failed DNS lookups,
     # socket connections and connection timeouts.
@@ -53,13 +53,6 @@ def get(ctx, env, col_id, col_version, output_dir, book_tree, get_resources):
     if resp.status_code >= 400:
         raise MissingContent(col_id, req_version)
     col_metadata = resp.json()
-    if col_metadata['collated']:
-        url = resp.url + '?as_collated=False'
-        resp = session.get(url)
-        if resp.status_code >= 400:
-            # This should never happen - indicates that only baked exists?
-            raise MissingContent(col_id, req_version)
-        col_metadata = resp.json()
     uuid = col_metadata['id']
     # metadata fetch used legacy IDs, so will only have
     # the latest minor version - if "version" is set, the

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -552,35 +552,3 @@ class TestGetCmd:
 
         msg = "content unavailable for '{}/{}'".format(col_id, col_ver)
         assert msg in result.output
-
-    def test_failed_request_no_raw(self, datadir, requests_mock, invoker):
-        col_id = 'col11405'
-        col_version = 'latest'
-        col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
-        col_hash = '{}@{}'.format(col_uuid, '2.1')
-        base_url = 'https://archive.cnx.org'
-        metadata_url = '{}/content/{}/{}'.format(base_url, col_id, col_version)
-        extras_url = '{}/extras/{}'.format(base_url, col_hash)
-        contents_url = '{}/contents/{}'.format(base_url, col_hash)
-        raw_url = '{}/contents/{}?as_collated=False'.format(base_url, col_hash)
-
-        # Register the data urls
-        for fname, url in (('contents.json', contents_url),
-                           ('extras.json', extras_url),
-                           ):
-            register_data_file(requests_mock, datadir, fname, url)
-
-        requests_mock.get(metadata_url,
-                          status_code=301,
-                          headers={'location': contents_url})
-
-        register_404(requests_mock, raw_url)
-
-        from nebu.cli.main import cli
-        args = ['get', 'test-env', col_id, col_version]
-        result = invoker(cli, args)
-
-        assert result.exit_code == 4
-
-        msg = "content unavailable for '{}/{}'".format(col_id, col_version)
-        assert msg in result.output


### PR DESCRIPTION
This code has been removed, because the `get` command will always want the
collated version (aka raw). Just ask for the non-collated form to begin with.

The comment that has been removed also notes that "this should never happen".