### PR TITLE
Write content to disk as bytes

### DIFF
--- a/nebu/cli/get.py
+++ b/nebu/cli/get.py
@@ -205,7 +205,7 @@ def _write_node(node, base_url, out_dir, book_tree=False, get_resources=False,
         gen_resources_sha1_cache(write_dir, resources)
 
         # core files are XML - this parse/serialize removes numeric entities
-        filepath.write_bytes(etree.tostring(etree.XML(file_resp.text),
+        filepath.write_bytes(etree.tostring(etree.XML(file_resp.content),
                                             encoding='utf-8'))
 
         if get_resources:

--- a/nebu/tests/data/unicode.cnxml
+++ b/nebu/tests/data/unicode.cnxml
@@ -1,0 +1,61 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:md="http://cnx.rice.edu/mdml" id="imp-idm502145136" cnxml-version="0.8" module-id="new">
+  <title>Dylatacja czasu</title>
+  <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <!-- WARNING! The 'metadata' section is read only. Do not edit below.
+       Changes to the metadata section in the source will not be saved. -->
+  <md:repository>https://legacy.cnx.org/content</md:repository>
+  <md:content-url>https://legacy.cnx.org/content/m68234/latest/</md:content-url>
+  <md:content-id>m68234</md:content-id>
+  <md:title>Dylatacja czasu</md:title>
+  <md:version>1.3</md:version>
+  <md:created>2017/02/17 15:33:33 -0600</md:created>
+  <md:revised>2018/08/08 11:39:32.819 GMT-5</md:revised>
+  <md:actors>
+    <md:person userid="katalysteducation">
+      <md:firstname>Katalyst</md:firstname>
+      <md:surname>Education</md:surname>
+      <md:fullname>Katalyst Education</md:fullname>
+      <md:email>katalyst.education@gmail.com</md:email>
+    </md:person>
+  </md:actors>
+  <md:roles>
+    <md:role type="author">katalysteducation</md:role>
+    <md:role type="maintainer">katalysteducation</md:role>
+    <md:role type="licensor">katalysteducation</md:role>
+  </md:roles>
+  <md:license url="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License 4.0</md:license>
+  <!-- For information on license requirements for use or modification, see license url in the
+       above <md:license> element.
+       For information on formatting required attribution, see the URL:
+         CONTENT_URL/content_info#cnx_cite_header
+       where CONTENT_URL is the value provided above in the <md:content-url> element.
+  -->
+  <md:derived-from url="https://legacy.cnx.org/content/m58563/1.2/">
+  </md:derived-from>
+  <md:keywordlist>
+    <md:keyword>czas własny</md:keyword>
+    <md:keyword>dylatacja czasu</md:keyword>
+    <md:keyword>proper time</md:keyword>
+    <md:keyword>time dilation</md:keyword>
+  </md:keywordlist>
+  <md:subjectlist>
+    <md:subject>Science and Technology</md:subject>
+  </md:subjectlist>
+  <md:abstract>W tym podrozdziale nauczysz się:
+<list>
+<item>dlaczego mierzony upływ czasu może być inny w różnych układach odniesienia;</item>
+<item>w jaki sposób odróżnić czas własny od czasu innego obserwatora;</item>
+<item>opisywać znaczenie eksperymentu Rossiego-Halla;</item>
+<item>dlaczego paradoks bliźniąt nie jest sprzecznością;</item>
+<item>obliczać dylatację czasu, znając prędkość ciała w danym układzie.</item>
+</list></md:abstract>
+  <md:language>pl</md:language>
+  <!-- WARNING! The 'metadata' section is read only. Do not edit above.
+       Changes to the metadata section in the source will not be saved. -->
+</metadata>
+
+<content id="module">
+    <para id="paragraph-9">Przeprowadzona w poprzednim podrozdziale analiza jednoczesności zdarzeń zwraca uwagę na pewien wniosek płynący z postulatów Einsteina: odcinki czasu mają różne wartości w różnych układach odniesienia. Dla przykładu załóżmy, że astronauta mierzy czas, jakiego potrzebuje impuls światła do pokonania odległości między zwierciadłem a źródłem, biegnąc tam i z powrotem (<link target-id="figure-1"/>), poruszając się prostopadle do ruchu promu (względem obserwatora na Ziemi). Jak ma się wartość zmierzona przez astronautę do czasu trwania zdarzenia dla obserwatora znajdującego się na powierzchni Ziemi?
+    </para>
+</content>
+</document>


### PR DESCRIPTION
The change uses the `content` attribute of a request object, which contains
bytes data. The `text` attribute converts the `content` (or `raw`) attribute
to a string of ascii. This doesn't work for unicode chars that can't be
converted to ascii.

Addresses openstax/cnx#291