### PR TITLE
Don't clear the output dir in neb assemble

### DIFF
--- a/nebu/cli/assemble.py
+++ b/nebu/cli/assemble.py
@@ -13,8 +13,11 @@ from ..models.utils import scan_for_id_mapping
 from ..utils import relative_path
 
 
+ASSEMBLED_FILENAME = 'collection.assembled.xhtml'
+
+
 def produce_collection_xhtml(binder, output_dir):
-    collection_xhtml = output_dir / 'collection.assembled.xhtml'
+    collection_xhtml = output_dir / ASSEMBLED_FILENAME
     with collection_xhtml.open('wb') as fb:
         fb.write(bytes(SingleHTMLFormatter(binder)))
 
@@ -47,14 +50,15 @@ def assemble(ctx, input_dir, output_dir):
     """
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)
+    collection_assembled_xhtml = (output_dir / ASSEMBLED_FILENAME)
 
-    if (output_dir / 'collection.assembled.xhtml').exists():
+    if collection_assembled_xhtml.exists():
         confirm_msg = (
             "This will remove '{}', continue?"
-            .format(output_dir / 'collection.assembled.xhtml')
+            .format(collection_assembled_xhtml)
         )
         click.confirm(confirm_msg, abort=True, err=True)
-        (output_dir / 'collection.assembled.xhtml').unlink()
+        collection_assembled_xhtml.unlink()
     if not output_dir.exists():
         output_dir.mkdir()
 

--- a/nebu/tests/cli/test_assemble.py
+++ b/nebu/tests/cli/test_assemble.py
@@ -69,10 +69,24 @@ class TestAssembleCmd:
         expected_dir = (src_data / 'm46882').resolve()
         assert Path(str(m46882_dir.resolve())) == expected_dir
 
-    def test_output_dir_exists_proceed(self, tmp_path, src_data, result_data,
-                                       invoker):
+    def test_output_dir_exists(self, tmp_path, src_data, invoker):
         output_dir = tmp_path / 'build'
         output_dir.mkdir()
+
+        from nebu.cli.main import cli
+        args = [
+            'assemble',  # (target)
+            str(src_data), str(output_dir),
+        ]
+        result = invoker(cli, args)
+
+        # Verify the invocation output
+        assert result.exit_code == 0, result.output
+
+    def test_output_file_exists_proceed(self, tmp_path, src_data, invoker):
+        output_dir = tmp_path / 'build'
+        output_dir.mkdir()
+        (output_dir / 'collection.assembled.xhtml').touch()
 
         from nebu.cli.main import cli
         args = [
@@ -84,10 +98,10 @@ class TestAssembleCmd:
         # Verify the invocation output
         assert result.exit_code == 0, result.output
 
-    def test_output_dir_exists_abort(self, tmp_path, src_data, result_data,
-                                     invoker):
+    def test_output_file_exists_abort(self, tmp_path, src_data, invoker):
         output_dir = tmp_path / 'build'
         output_dir.mkdir()
+        (output_dir / 'collection.assembled.xhtml').touch()
 
         from nebu.cli.main import cli
         args = [


### PR DESCRIPTION
"neb assemble" doesn't expect the output dir to exist and if it does, it
removes the whole directory.

Having an output directory specified by the user is going to be
problematic when we get to the later commands, mathify and pdf, because
the output directory has lots of symlinks to the input directory and
those aren't going to work when mounted in the docker container.

One of the ways to get this to work is to have the output directory as
the parent directory of the input directory.  That way, when the output
directory is mounted, the symlinks are going to work correctly.