### PR TITLE
 Revert defaulting to using the non-collated version

### DIFF
--- a/nebu/cli/get.py
+++ b/nebu/cli/get.py
@@ -40,7 +40,7 @@ def get(ctx, env, col_id, col_version, output_dir, book_tree, get_resources):
 
     col_hash = '{}/{}'.format(col_id, col_version)
     # Fetch metadata
-    url = '{}/content/{}?as_collated=False'.format(base_url, col_hash)
+    url = '{}/content/{}'.format(base_url, col_hash)
 
     # Create a request session with retries if there's failed DNS lookups,
     # socket connections and connection timeouts.
@@ -53,6 +53,13 @@ def get(ctx, env, col_id, col_version, output_dir, book_tree, get_resources):
     if resp.status_code >= 400:
         raise MissingContent(col_id, req_version)
     col_metadata = resp.json()
+    if col_metadata['collated']:
+        url = resp.url + '?as_collated=False'
+        resp = session.get(url)
+        if resp.status_code >= 400:
+            # This should never happen - indicates that only baked exists?
+            raise MissingContent(col_id, req_version)
+        col_metadata = resp.json()
     uuid = col_metadata['id']
     # metadata fetch used legacy IDs, so will only have
     # the latest minor version - if "version" is set, the

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -598,3 +598,35 @@ class TestGetCmd:
 
         msg = "content unavailable for '{}/{}'".format(col_id, col_ver)
         assert msg in result.output
+
+    def test_failed_request_no_raw(self, datadir, requests_mock, invoker):
+        col_id = 'col11405'
+        col_version = 'latest'
+        col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
+        col_hash = '{}@{}'.format(col_uuid, '2.1')
+        base_url = 'https://archive.cnx.org'
+        metadata_url = '{}/content/{}/{}'.format(base_url, col_id, col_version)
+        extras_url = '{}/extras/{}'.format(base_url, col_hash)
+        contents_url = '{}/contents/{}'.format(base_url, col_hash)
+        raw_url = '{}/contents/{}?as_collated=False'.format(base_url, col_hash)
+
+        # Register the data urls
+        for fname, url in (('contents.json', contents_url),
+                           ('extras.json', extras_url),
+                           ):
+            register_data_file(requests_mock, datadir, fname, url)
+
+        requests_mock.get(metadata_url,
+                          status_code=301,
+                          headers={'location': contents_url})
+
+        register_404(requests_mock, raw_url)
+
+        from nebu.cli.main import cli
+        args = ['get', 'test-env', col_id, col_version]
+        result = invoker(cli, args)
+
+        assert result.exit_code == 4
+
+        msg = "content unavailable for '{}/{}'".format(col_id, col_version)
+        assert msg in result.output


### PR DESCRIPTION
This reverts #143, which is required because of how we are using a redirect to the archive's metadata. The route on archive unfortunately doesn't pass along the query string. (I'm not sure it pass along the query string, but I'm kinda on the fence about that.) This at any rate, reverts the change and puts comments in place to explain what's happening, so that I or someone else doesn't yank it out again. 😝 