### PR TITLE
Fix internal links in "neb assemble"

### DIFF
--- a/nebu/models/binder.py
+++ b/nebu/models/binder.py
@@ -1,3 +1,5 @@
+import re
+
 from lxml import etree
 from cnxml.parse import parse_metadata as parse_cnxml_metadata
 from cnxepub.models import (
@@ -104,10 +106,16 @@ class Binder(BaseBinder):
     def _make_reference_resolver(id):
 
         def func(reference, resource):
-            reference.bind(
-                resource,
-                '{}/{{}}'.format(id),
-            )
+            if resource:
+                reference.bind(
+                    resource,
+                    '{}/{{}}'.format(id),
+                )
+            elif re.match('/m[0-9]+.*', reference.uri):
+                # SingleHTMLFormatter looks for links that start with
+                # "/contents/" for intra book links.  These links are important
+                # for baking to work.
+                reference.uri = '/contents{}'.format(reference.uri)
 
         return func
 

--- a/nebu/models/document.py
+++ b/nebu/models/document.py
@@ -166,6 +166,5 @@ class Document(BaseDocument):
                 # When resources are missing, the problem is pushed off
                 # to the rendering process, which will
                 # raise a missing reference exception when necessary.
-                pass
-            else:
-                self._reference_resolver(ref, resource)
+                resource = None
+            self._reference_resolver(ref, resource)

--- a/nebu/tests/models/test_document.py
+++ b/nebu/tests/models/test_document.py
@@ -41,7 +41,8 @@ M46882_METADATA = {
 
 def mock_reference_resolver(reference, resource):
     """Used for testing reference resolution during model tests"""
-    reference.bind(resource, '{}/{{}}'.format(REFERENCE_MARKER))
+    if resource:
+        reference.bind(resource, '{}/{{}}'.format(REFERENCE_MARKER))
 
 
 class TestDocument(object):


### PR DESCRIPTION
Internal links to other parts of the book were not recognized by the
SingleHTMLFormatter.  If it linked to an image or an equation, after
baking, the correct link text (e.g. "Figure 2.10") can't be generated.

For internal links to work correctly, we need to prepend it with
"/contents/".  The SingleHTMLFormatter will look for the page ID to see
if it's within the book and rewrite the link accordingly.