### PR TITLE
Fix assemble when collection.xml doesn't use all modules

### DIFF
--- a/nebu/cli/assemble.py
+++ b/nebu/cli/assemble.py
@@ -27,13 +27,14 @@ def produce_collection_xhtml(binder, output_dir):
 def provide_supporting_files(input_dir, output_dir, binder):
     documents = {doc.id: doc for doc in flatten_to_documents(binder)}
     for id, filepath in scan_for_id_mapping(input_dir).items():
-        if (output_dir / id).exists():
-            (output_dir / id).unlink()
-        (output_dir / id).symlink_to(
-            relative_path(filepath.parent, output_dir)
-        )
-        with (output_dir / '{}.xhtml'.format(id)).open('wb') as fb:
-            fb.write(bytes(HTMLFormatter(documents[id])))
+        if id in documents:
+            if (output_dir / id).exists():
+                (output_dir / id).unlink()
+            (output_dir / id).symlink_to(
+                relative_path(filepath.parent, output_dir)
+            )
+            with (output_dir / '{}.xhtml'.format(id)).open('wb') as fb:
+                fb.write(bytes(HTMLFormatter(documents[id])))
 
 
 @click.command(name='assemble')


### PR DESCRIPTION
When I ran `neb assemble` after editing collection.xml to remove half of the
book for testing, I ran into this error:

```
karen@yachiyo:~/src/cnx-recipes$ ./venv.local/bin/neb assemble data/intermediate-algebra/raw/ data/intermediate-algebra/
This will remove 'data/intermediate-algebra/collection.assembled.xhtml', continue? [y/N]: y
Traceback (most recent call last):
  File "./venv.local/bin/neb", line 10, in <module>
    sys.exit(cli())
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/nebu/cli/_common.py", line 54, in wrapper
    return func(*args, **kwargs)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/nebu/cli/assemble.py", line 81, in assemble
    provide_supporting_files(input_dir, output_dir, binder)
  File "/home/karen/src/cnx-recipes/venv.local/lib/python3.6/site-packages/nebu/cli/assemble.py", line 36, in provide_supporting_files
    fb.write(bytes(HTMLFormatter(documents[id])))
KeyError: 'm63462'
```

This happens when the module exists in the input directory but is not
used in collection.xml.  The problem is in the symlink creation code
`provide_supporting_files`.  It has now been fixed to check if the
module is in the collection before creating the symlink.