### PR TITLE
WIP Add `content-task` command

### DIFF
--- a/nebu/cli/content_task.py
+++ b/nebu/cli/content_task.py
@@ -51,8 +51,8 @@ def content_task(ctx, task_file_path, content_dir, task_args):
         if 'collection.xml' in filenames:
             collection = parse_collection(path, excludes=ex)
             action_params = to_str_dict(collection)
-            collection_action(**action_params)
+            collection_action(**action_params, args=task_args)
         elif 'index.cnxml' in filenames:
             module = parse_module(path, excludes=ex)
             action_params = to_str_dict(module)
-            module_action(**action_params)
+            module_action(**action_params, args=task_args)

--- a/nebu/cli/content_task.py
+++ b/nebu/cli/content_task.py
@@ -15,25 +15,25 @@ from ._common import common_params
 
 @click.command()
 @common_params
-@click.argument('plugin',
+@click.argument('task_file_path',
                 type=click.Path(exists=True, dir_okay=False))
 @click.argument('content_dir',
                 type=click.Path(exists=True, file_okay=False))
-@click.argument('plugin_args', nargs=-1)
+@click.argument('task_args', nargs=-1)
 @click.pass_context
-def plugin(ctx, plugin, content_dir, plugin_args):
-    plugin_spec = spec_from_file_location('plugin', plugin)
-    plugin_module = module_from_spec(plugin_spec)
-    plugin_spec.loader.exec_module(plugin_module)
+def content_task(ctx, task_file_path, content_dir, task_args):
+    task_spec = spec_from_file_location('content_task', task_file_path)
+    task_module = module_from_spec(task_spec)
+    task_spec.loader.exec_module(task_module)
 
     def noop(*args, **kwargs):
         pass
 
-    collection_action = (plugin_module.with_collection
-        if hasattr(plugin_module, 'with_collection')
+    collection_action = (task_module.with_collection
+        if hasattr(task_module, 'with_collection')
         else noop)
-    module_action = (plugin_module.with_module
-        if hasattr(plugin_module, 'with_module')
+    module_action = (task_module.with_module
+        if hasattr(task_module, 'with_module')
         else noop)
 
     def to_str_dict(collection_or_module):

--- a/nebu/cli/content_task.py
+++ b/nebu/cli/content_task.py
@@ -1,17 +1,15 @@
 import os
-import sys
-import imp
 from pathlib import Path
 from importlib.util import spec_from_file_location, module_from_spec
 
 import click
-from lxml import etree
 from litezip import (
     parse_collection,
     parse_module
 )
 
 from ._common import common_params
+
 
 @click.command()
 @common_params
@@ -30,11 +28,11 @@ def content_task(ctx, task_file_path, content_dir, task_args):
         pass
 
     collection_action = (task_module.with_collection
-        if hasattr(task_module, 'with_collection')
-        else noop)
+                         if hasattr(task_module, 'with_collection')
+                         else noop)
     module_action = (task_module.with_module
-        if hasattr(task_module, 'with_module')
-        else noop)
+                     if hasattr(task_module, 'with_module')
+                     else noop)
 
     def to_str_dict(collection_or_module):
         return {
@@ -58,4 +56,3 @@ def content_task(ctx, task_file_path, content_dir, task_args):
             module = parse_module(path, excludes=ex)
             action_params = to_str_dict(module)
             module_action(**action_params)
-

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -13,7 +13,7 @@ from .get import get
 from .environment import list_environments
 from .publish import publish
 from .validate import validate
-from .plugin import plugin
+from .content_task import content_task
 
 
 __all__ = ('cli',)
@@ -98,7 +98,7 @@ def cli(ctx):
 cli.add_command(assemble)
 cli.add_command(config_atom)
 cli.add_command(get)
-cli.add_command(plugin)
+cli.add_command(content_task)
 cli.add_command(list_environments)
 cli.add_command(publish)
 cli.add_command(validate)

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -13,6 +13,7 @@ from .get import get
 from .environment import list_environments
 from .publish import publish
 from .validate import validate
+from .plugin import plugin
 
 
 __all__ = ('cli',)
@@ -97,6 +98,7 @@ def cli(ctx):
 cli.add_command(assemble)
 cli.add_command(config_atom)
 cli.add_command(get)
+cli.add_command(plugin)
 cli.add_command(list_environments)
 cli.add_command(publish)
 cli.add_command(validate)

--- a/nebu/cli/plugin.py
+++ b/nebu/cli/plugin.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import imp
+from pathlib import Path
+from importlib.util import spec_from_file_location, module_from_spec
+
+import click
+from lxml import etree
+from litezip import (
+    parse_collection,
+    parse_module
+)
+# from litezip.main import COLLECTION_NSMAP
+
+from ._common import common_params
+
+@click.command()
+@common_params
+@click.argument('plugin',
+                type=click.Path(exists=True, dir_okay=False))
+@click.argument('content_dir',
+                type=click.Path(exists=True, file_okay=False))
+@click.argument('plugin_args', nargs=-1)
+@click.pass_context
+def plugin(ctx, plugin, content_dir, plugin_args):
+    plugin_spec = spec_from_file_location('plugin', plugin)
+    plugin_module = module_from_spec(plugin_spec)
+    plugin_spec.loader.exec_module(plugin_module)
+
+    def noop(*args, **kwargs):
+        pass
+
+    collection_action = (plugin_module.with_collection
+        if hasattr(plugin_module, 'with_collection')
+        else noop)
+    module_action = (plugin_module.with_module
+        if hasattr(plugin_module, 'with_module')
+        else noop)
+
+    def to_str_dict(collection_or_module):
+        return {
+            'id': str(collection_or_module.id),
+            'file': str(collection_or_module.file),
+            'resources': list(map(
+                lambda resource: str(resource.data),
+                collection_or_module.resources
+            ))
+        }
+
+    content_dir = Path(content_dir).resolve()
+    ex = [lambda filepath: '.sha1sum' in filepath.name]
+    for dirname, subdirs, filenames in os.walk(str(content_dir)):
+        path = Path(dirname)
+        if 'collection.xml' in filenames:
+            collection = parse_collection(path, excludes=ex)
+            action_params = to_str_dict(collection)
+            collection_action(**action_params)
+        elif 'index.cnxml' in filenames:
+            module = parse_module(path, excludes=ex)
+            action_params = to_str_dict(module)
+            module_action(**action_params)
+

--- a/nebu/cli/plugin.py
+++ b/nebu/cli/plugin.py
@@ -10,7 +10,6 @@ from litezip import (
     parse_collection,
     parse_module
 )
-# from litezip.main import COLLECTION_NSMAP
 
 from ._common import common_params
 


### PR DESCRIPTION
This can allow us the possibility to have neatly packaged utility scripts that will need to undergo less maintenance and testing by developer teams.
Note: I know that there are no tests here right now. I want to make sure this solution holds water before I take the time to write them.

Some things this might help us solve:
- https://github.com/openstax/cnx/issues/224

- Larissa mentioned it would also be helpful to have something to automate things like removing empty cnxml elements, so that CMs don't have to slog through so much content.

- Any automatable task that the CMs would want to accomplish with locally checked out markup

As an example, https://github.com/openstax/cnx/issues/224 can potentially be solved with a external  content-task script with this source:
```python
from lxml import etree
import os

from litezip.main import COLLECTION_NSMAP

def with_module(id, file, resources, args):
  resource_basenames = list(map(lambda path: os.path.basename(path), resources))
  tree = etree.parse(file)
  content_srcs = tree.xpath('//c:image/@src', namespaces=COLLECTION_NSMAP)
  print(f'module {id}')
  for src in content_srcs:
    if not src in resource_basenames:
      print(f'Missing {src} in module {id}')
  for resource_name in resource_basenames:
    if not resource_name in content_srcs:
      print(f'Unused img {resource_name} in module {id}')
  print('-----')
```