### PR TITLE
Add neb-tasks

### DIFF
--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -56,3 +56,66 @@ def test_no_versions_found():
     def empty_version_list():
         return []
     assert get_latest_released_version(empty_version_list) == ""
+
+
+def test_help_formatter(invoker):
+    import textwrap
+    import click
+    from nebu.cli.main import HelpSectionsGroup
+
+    @click.group(cls=HelpSectionsGroup)
+    def cli(ctx):
+        pass
+
+    @cli.command(help_section='a')
+    def a():
+        pass
+
+    @cli.command(help_section='b')
+    def b():
+        pass
+
+    args = ['--help']
+    result = invoker(cli, args)
+
+    assert result.exit_code == 0
+
+    expected_output = textwrap.dedent("""
+    Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      [a]
+      a
+
+      [b]
+      b
+    """)
+
+    assert ('\n' + result.output) == expected_output
+
+
+def test_help_formatter_no_cmd(invoker):
+    import textwrap
+    import click
+    from nebu.cli.main import HelpSectionsGroup
+
+    @click.group(cls=HelpSectionsGroup)
+    def cli(ctx):
+        pass
+
+    args = ['--help']
+    result = invoker(cli, args)
+
+    assert result.exit_code == 0
+
+    expected_output = textwrap.dedent("""
+    Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+    Options:
+      --help  Show this message and exit.
+    """)
+
+    assert ('\n' + result.output) == expected_output

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = parse_requirements('requirements/main.txt')
 tests_require = parse_requirements('requirements/test.txt')
 extras_require = {
     'test': tests_require,
+    'tasks': 'neb-tasks @ git+https://github.com/openstax/neb-tasks.git@master#egg=neb-tasks', # noqa
 }
 description = "OpenStax Nebu publishing utility"
 with open('README.rst', 'r') as readme:

--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,16 @@ tests_require = parse_requirements('requirements/test.txt')
 extras_require = {
     'test': tests_require,
 }
-description = "Connexions Nebu publishing utility"
+description = "OpenStax Nebu publishing utility"
 with open('README.rst', 'r') as readme:
     long_description = readme.read()
 
 setup(
     name='nebuchadnezzar',
     version=versioneer.get_version(),
-    author='Connexions team',
+    author='OpenStax team',
     author_email='info@cnx.org',
-    url="https://github.com/connexions/nebuchadnezzar",
+    url="https://github.com/openstax/nebuchadnezzar",
     license='AGPL, See also LICENSE.txt',
     description=description,
     long_description=long_description,


### PR DESCRIPTION
Remix of https://github.com/openstax/nebuchadnezzar/pull/156 but with a different implementation strategy. This time for real.

This can allow us to have neatly packaged utility scripts that will need to undergo less maintenance and testing by developer teams. These scripts could come from any dependency, but for right now, only from the new `neb-tasks` repo, which is added as an optional dependency to neb. These scripts, given the proper decorators, are added as commands in the Neb CLI.

This PR also adds sections to the CLI help output. Example:
![neb-help](https://user-images.githubusercontent.com/1285308/66870789-d7a38a80-ef67-11e9-977a-dd380d14eb3b.png)

Some things this might help us solve:
- https://github.com/openstax/cnx/issues/224

- Larissa mentioned it would also be helpful to have something to automate things like removing empty cnxml elements, so that CMs don't have to slog through so much content.

- A more officially supported stale content merge tool

- Any automatable task, not required in our server-side pipelines or CLIs, that the CMs would want to accomplish with locally checked out markup

As an example, https://github.com/openstax/cnx/issues/224 can potentially be resolved with an external script at https://github.com/openstax/neb-tasks/blob/master/nebtasks/tasks/broken_imgs.py