### PR TITLE
Add "ping" command to check credentials and permissions

### DIFF
--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -13,6 +13,7 @@ from .assemble import assemble
 from .atom import config_atom
 from .get import get
 from .environment import list_environments
+from .ping import ping
 from .publish import publish
 from .validate import validate
 
@@ -151,6 +152,7 @@ cli.add_command(assemble, help_section='Stock')
 cli.add_command(config_atom, help_section='Stock')
 cli.add_command(get, help_section='Stock')
 cli.add_command(list_environments, help_section='Stock')
+cli.add_command(ping, help_section='Stock')
 cli.add_command(publish, help_section='Stock')
 cli.add_command(validate, help_section='Stock')
 

--- a/nebu/cli/ping.py
+++ b/nebu/cli/ping.py
@@ -1,0 +1,47 @@
+import sys
+
+import click
+import requests
+from requests.auth import HTTPBasicAuth
+
+from ._common import common_params, get_base_url, logger
+
+
+@click.command()
+@common_params
+@click.argument('env')
+@click.option('-u', '--username', type=str, prompt=True)
+@click.option('-p', '--password', type=str, prompt=True)
+@click.pass_context
+def ping(ctx, env, username, password):
+    """Check credentials and permission to publish on server"""
+    base_url = get_base_url(ctx, env)
+
+    auth = HTTPBasicAuth(username, password)
+    auth_ping_url = '{}/api/auth-ping'.format(base_url)
+    auth_ping_resp = requests.get(auth_ping_url, auth=auth)
+
+    if auth_ping_resp.status_code == 401:
+        logger.error('Bad credentials: \n{}'.format(
+            auth_ping_resp.content.decode('utf-8')))
+        sys.exit(1)
+    elif auth_ping_resp.status_code != 200:
+        logger.error('Server error (status code: {})\n{}'.format(
+            auth_ping_resp.status_code,
+            auth_ping_resp.content.decode('utf-8')))
+        sys.exit(1)
+
+    publish_ping_url = '{}/api/publish-ping'.format(base_url)
+    publish_ping_resp = requests.get(publish_ping_url, auth=auth)
+
+    if publish_ping_resp.status_code == 401:
+        logger.error('Publishing not allowed: \n{}'.format(
+            publish_ping_resp.content.decode('utf-8')))
+        sys.exit(1)
+    elif publish_ping_resp.status_code != 200:
+        logger.error('Server error (status code: {})\n{}'.format(
+            publish_ping_resp.status_code,
+            publish_ping_resp.content.decode('utf-8')))
+        sys.exit(1)
+
+    logger.info('The user has permission to publish on this server.')

--- a/nebu/tests/cli/test_ping.py
+++ b/nebu/tests/cli/test_ping.py
@@ -1,0 +1,89 @@
+class TestPingCmd:
+    def test_auth_ping_internal_server_error(self, requests_mock, invoker):
+        # Mock the auth ping request
+        url = 'https://cnx.org/api/auth-ping'
+        requests_mock.register_uri('GET', url, status_code=500,
+                                   text='Internal server error')
+
+        from nebu.cli.main import cli
+        args = ['ping', 'test-env', '-u', 'someusername', '-p', 'somepassword']
+        result = invoker(cli, args)
+
+        assert result.exit_code == 1
+        assert 'Internal server error' in result.output
+
+        if result.exception and not isinstance(result.exception, SystemExit):
+            raise result.exception
+
+    def test_publish_ping_internal_server_error(self, requests_mock, invoker):
+        # Mock the ping requests
+        url = 'https://cnx.org/api/auth-ping'
+        requests_mock.register_uri('GET', url, status_code=200,
+                                   text='OK')
+        url = 'https://cnx.org/api/publish-ping'
+        requests_mock.register_uri('GET', url, status_code=500,
+                                   text='Internal server error')
+
+        from nebu.cli.main import cli
+        args = ['ping', 'test-env', '-u', 'someusername', '-p', 'somepassword']
+        result = invoker(cli, args)
+
+        assert result.exit_code == 1
+        assert 'Internal server error' in result.output
+
+        if result.exception and not isinstance(result.exception, SystemExit):
+            raise result.exception
+
+    def test_bad_credentials(self, requests_mock, invoker):
+        # Mock the auth ping request
+        url = 'https://cnx.org/api/auth-ping'
+        requests_mock.register_uri('GET', url, status_code=401,
+                                   text='Nothing to see')
+
+        from nebu.cli.main import cli
+        args = ['ping', 'test-env', '-u', 'someusername', '-p', '!']
+        result = invoker(cli, args)
+
+        assert result.exit_code == 1
+        assert 'Bad credentials' in result.output
+
+        if result.exception and not isinstance(result.exception, SystemExit):
+            raise result.exception
+
+    def test_no_permission_to_publish(self, requests_mock, invoker):
+        # Mock the ping requests
+        url = 'https://cnx.org/api/auth-ping'
+        requests_mock.register_uri('GET', url, status_code=200,
+                                   text='OK')
+        url = 'https://cnx.org/api/publish-ping'
+        requests_mock.register_uri('GET', url, status_code=401,
+                                   text='Nothing to see')
+
+        from nebu.cli.main import cli
+        args = ['ping', 'test-env', '-u', 'someusername', '-p', '!']
+        result = invoker(cli, args)
+
+        assert result.exit_code == 1
+        assert 'Publishing not allowed' in result.output
+
+        if result.exception and not isinstance(result.exception, SystemExit):
+            raise result.exception
+
+    def test_ok(self, requests_mock, invoker):
+        # Mock the ping requests
+        url = 'https://cnx.org/api/auth-ping'
+        requests_mock.register_uri('GET', url, status_code=200,
+                                   text='OK')
+        url = 'https://cnx.org/api/publish-ping'
+        requests_mock.register_uri('GET', url, status_code=200,
+                                   text='OK')
+
+        from nebu.cli.main import cli
+        args = ['ping', 'test-env', '-u', 'someusername', '-p', '!']
+        result = invoker(cli, args)
+
+        assert result.exit_code == 0
+        assert 'The user has permission to publish' in result.output
+
+        if result.exception and not isinstance(result.exception, SystemExit):
+            raise result.exception


### PR DESCRIPTION
There is currently no quick way to determine whether a user has
permission to publish on a server or not, so this is to let us find out
without publishing anything.

Example usage:

```
neb ping -u manager -p xxxx content01
```

will respond with one of these messages:

```
Server error (status code: 500)
Internal Server Error

The server encountered an unexpected internal server error

(generated by waitress)
```

```
Publishing not allowed:
{"messages": [{"id": 5, "message": "Unauthorized", "error": "Nothing to see here."}]}
```

```
Bad credentials:
{"messages": [{"id": 5, "message": "Unauthorized", "error": "Nothing to see here."}]}
```

```
The user has permission to publish on this server.
```