### PR TITLE
Remove neb-task as an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ install_requires = parse_requirements('requirements/main.txt')
 tests_require = parse_requirements('requirements/test.txt')
 extras_require = {
     'test': tests_require,
-    'tasks': 'neb-tasks @ git+https://github.com/openstax/neb-tasks.git@master#egg=neb-tasks', # noqa
 }
 description = "OpenStax Nebu publishing utility"
 with open('README.rst', 'r') as readme:


### PR DESCRIPTION
It is currently not possible to upload nebuchadnezzar (v9.2.0) on pypi
with a direct dependency.

```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading nebuchadnezzar-9.2.0-py3-none-any.whl
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 103k/103k [00:01<00:00, 86.6kB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Client Error: Invalid value for requires_dist. Error: Can't have direct dependency: "neb-tasks @ git+https://github.com/openstax/neb-tasks.git@master#egg=neb-tasks ; extra == 'tasks'" for url: https://upload.pypi.org/legacy/
```

We can either package neb-tasks and release it on pypi or ask the user to pip
install from github.