### PR TITLE
Upgrade codebase to work with Python >=3.5 <=3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.5"
+  - "3.7"
 before_install:
   - make lint
 script:

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ This is a command-line interface for interacting with connexions content. The to
 
 This software requires:
 
-- Python >= 3.5
+- Python >= 3.5 <= 3.7
 - libmagic (libmagic1 on Linux)
 - JRE >= 6
 

--- a/nebu/tests/cli/test_publish.py
+++ b/nebu/tests/cli/test_publish.py
@@ -6,6 +6,14 @@ from requests.auth import HTTPBasicAuth
 import pretend
 
 
+def ensure_str(s):
+    """Ensure ``s`` is a str type"""
+    if isinstance(s, bytes):
+        return s.decode()
+    else:
+        return s
+
+
 class MockRequest:
     def __init__(self):
         self.headers = {}
@@ -127,9 +135,11 @@ class TestPublishCmd:
         # Discover the multipart/form-data boundry
         boundary = request_data.split(b'\r\n')[0][2:]
         form = parse_multipart(io.BytesIO(request_data),
-                               {'boundary': boundary})
-        assert form['publisher'][0] == publisher.encode('utf8')
-        assert form['message'][0] == message.encode('utf8')
+                               {'boundary': boundary,
+                                'CONTENT-LENGTH': len(request_data),
+                                })
+        assert ensure_str(form['publisher'][0]) == publisher
+        assert ensure_str(form['message'][0]) == message
         # Check the zipfile for contents
         with zipfile.ZipFile(io.BytesIO(form['file'][0])) as zb:
             included_files = set(zb.namelist())
@@ -192,9 +202,11 @@ class TestPublishCmd:
         # Discover the multipart/form-data boundry
         boundary = request_data.split(b'\r\n')[0][2:]
         form = parse_multipart(io.BytesIO(request_data),
-                               {'boundary': boundary})
-        assert form['publisher'][0] == publisher.encode('utf8')
-        assert form['message'][0] == message.encode('utf8')
+                               {'boundary': boundary,
+                                'CONTENT-LENGTH': len(request_data),
+                                })
+        assert ensure_str(form['publisher'][0]) == publisher
+        assert ensure_str(form['message'][0]) == message
         # Check the zipfile for contents
         with zipfile.ZipFile(io.BytesIO(form['file'][0])) as zb:
             included_files = set(zb.namelist())
@@ -258,9 +270,11 @@ class TestPublishCmd:
         # Discover the multipart/form-data boundry
         boundary = request_data.split(b'\r\n')[0][2:]
         form = parse_multipart(io.BytesIO(request_data),
-                               {'boundary': boundary})
-        assert form['publisher'][0] == publisher.encode('utf8')
-        assert form['message'][0] == message.encode('utf8')
+                               {'boundary': boundary,
+                                'CONTENT-LENGTH': len(request_data),
+                                })
+        assert ensure_str(form['publisher'][0]) == publisher
+        assert ensure_str(form['message'][0]) == message
         # Check the zipfile for contents
         with zipfile.ZipFile(io.BytesIO(form['file'][0])) as zb:
             included_files = set(zb.namelist())
@@ -587,9 +601,11 @@ class TestPublishCmd:
         # Discover the multipart/form-data boundry
         boundary = request_data.split(b'\r\n')[0][2:]
         form = parse_multipart(io.BytesIO(request_data),
-                               {'boundary': boundary})
-        assert form['publisher'][0] == publisher.encode('utf8')
-        assert form['message'][0] == message.encode('utf8')
+                               {'boundary': boundary,
+                                'CONTENT-LENGTH': len(request_data),
+                                })
+        assert ensure_str(form['publisher'][0]) == publisher
+        assert ensure_str(form['message'][0]) == message
         # Check the zipfile for contents
         with zipfile.ZipFile(io.BytesIO(form['file'][0])) as zb:
             actual_published = set(zb.namelist())
@@ -666,9 +682,11 @@ class TestPublishCmd:
         # Discover the multipart/form-data boundry
         boundary = request_data.split(b'\r\n')[0][2:]
         form = parse_multipart(io.BytesIO(request_data),
-                               {'boundary': boundary})
-        assert form['publisher'][0] == publisher.encode('utf8')
-        assert form['message'][0] == message.encode('utf8')
+                               {'boundary': boundary,
+                                'CONTENT-LENGTH': len(request_data),
+                                })
+        assert ensure_str(form['publisher'][0]) == publisher
+        assert ensure_str(form['message'][0]) == message
         # Check the zipfile for contents
         with zipfile.ZipFile(io.BytesIO(form['file'][0])) as zb:
             actual_published = set(zb.namelist())
@@ -736,9 +754,11 @@ class TestPublishCmd:
         # Discover the multipart/form-data boundry
         boundary = request_data.split(b'\r\n')[0][2:]
         form = parse_multipart(io.BytesIO(request_data),
-                               {'boundary': boundary})
-        assert form['publisher'][0] == publisher.encode('utf8')
-        assert form['message'][0] == message.encode('utf8')
+                               {'boundary': boundary,
+                                'CONTENT-LENGTH': len(request_data),
+                                })
+        assert ensure_str(form['publisher'][0]) == publisher
+        assert ensure_str(form['message'][0]) == message
         # Check the zipfile for contents
         with zipfile.ZipFile(io.BytesIO(form['file'][0])) as zb:
             actual_published = set(zb.namelist())


### PR DESCRIPTION
This upgrades the code to run in Python 3.7 (and presumably 3.6) while still being compatible with Python 3.5.

For the most part the code itself runs fine in 3.x, but the tests needed tweaking with behavior changes in Python 3.7 to the `cgi` module's `parse_multipart` function, which started encoding the form data in 3.7.