### PR TITLE
Hide password input for neb ping

### DIFF
--- a/nebu/cli/ping.py
+++ b/nebu/cli/ping.py
@@ -11,7 +11,7 @@ from ._common import common_params, get_base_url, logger
 @common_params
 @click.argument('env')
 @click.option('-u', '--username', type=str, prompt=True)
-@click.option('-p', '--password', type=str, prompt=True)
+@click.option('-p', '--password', type=str, prompt=True, hide_input=True)
 @click.pass_context
 def ping(ctx, env, username, password):
     """Check credentials and permission to publish on server"""


### PR DESCRIPTION
Noticed that user password is not hidden when using neb ping. Went ahead and made the tiny fix.