### PR TITLE
Use asyncio for neb get

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+9.5.0
+-----
+
+- Use asyncio/aiohttp to speed up requests and improve performance of neb get (#166)
+
 9.4.0
 -----
 

--- a/nebu/cli/get.py
+++ b/nebu/cli/get.py
@@ -1,6 +1,7 @@
 import asyncio
 from itertools import groupby
 from traceback import print_tb
+import sys
 
 import click
 import requests
@@ -139,9 +140,9 @@ def report_and_quit(loop, context):  # pragma: no cover
     loop.default_exception_handler(context)
 
     exception = context.get('exception')
+    print(type(exception), file=sys.stderr)
     print_tb(exception.__traceback__)
-    print(type(exception))
-    print(str(exception))
+    print(str(exception), file=sys.stderr)
     loop.stop()
 
 

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -746,6 +746,57 @@ class TestGetCmd:
         msg = "content unavailable for '{}/{}'".format(col_id, col_version)
         assert msg in result.output
 
+    def test_internal_server_error(self,
+                                   capsys,
+                                   requests_mock,
+                                   mock_aioresponses,
+                                   datadir):
+        """At one point in time, modules which contained unicode characters
+         (used to) get ascii-encoded on dowload, and then we fixed it, but
+        this became an issue when detecting files that have changed because
+        the sha1 hash differs. This code tests that the hashing is done after
+        encoding.
+
+        See: https://github.com/openstax/cnx/issues/273
+        """
+        out_dir = Path(str(datadir))
+        base_url = 'https://archive.cnx.org'
+        node = {'id': 'foo'}
+        legacy_id = 'm68234'
+        resource_id = '9d85db7'
+
+        # Mock the request for the json data
+        metadata = {
+            'legacy_id': legacy_id,
+            'mediaType': 'application/vnd.org.cnx.module',
+            'resources': [
+                {
+                    "filename": "index.cnxml",
+                    "id": resource_id,
+                    "media_type": "application/octet-stream"
+                },
+            ],
+        }
+        url = '{}/contents/{}'.format(base_url, node['id'])
+        mock_aioresponses.get(url, payload=metadata)
+
+        url = '{}/resources/{}'.format(base_url, resource_id)
+        # Downloads the ascii-encoded module
+        mock_aioresponses.get(url,
+                              repeat=True,
+                              body='Internal Server Error',
+                              status=500)
+
+        # Call the target
+        try:
+            loop = asyncio.get_event_loop()
+            coro = _write_contents(node, base_url, out_dir)
+            loop.run_until_complete(coro)
+        except Exception:
+            assert 'Max retries exceeded' in capsys.readouterr().out
+        else:
+            assert False
+
     def test_sha1_with_non_utf8_content(self,
                                         requests_mock,
                                         mock_aioresponses,

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -785,7 +785,7 @@ class TestGetCmd:
         mock_aioresponses.get(url,
                               repeat=True,
                               body='Internal Server Error',
-                              status=500)
+                              status=503)
 
         # Call the target
         try:

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -792,8 +792,8 @@ class TestGetCmd:
             loop = asyncio.get_event_loop()
             coro = _write_contents(node, base_url, out_dir)
             loop.run_until_complete(coro)
-        except Exception:
-            assert 'Max retries exceeded' in capsys.readouterr().out
+        except RuntimeError:
+            assert 'Max retries exceeded' in capsys.readouterr().err
         else:
             assert False
 

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -1,8 +1,10 @@
 from functools import partial
 from os import scandir
 from pathlib import Path
+import traceback
+import asyncio
 
-from nebu.cli.get import _write_node
+from nebu.cli.get import _write_contents
 from nebu.cli._common import calculate_sha1
 
 
@@ -27,6 +29,28 @@ def register_data_file(requests_mock, datadir, filename, url):
         )
 
 
+def register_data_file_aio(mock_aioresponses, datadir, filename, url):
+    datafile = datadir / filename
+    content_size = datafile.stat().st_size
+    with datafile.open('rb') as fb:
+        headers = {'Content-Length': str(content_size)}
+        mock_aioresponses.get(
+            url,
+            body=fb.read(),
+            headers=headers,
+            repeat=True
+        )
+
+
+def register_404_aio(mock_aioresponses, url):
+    mock_aioresponses.get(
+        url,
+        body='Not Found',
+        status=404,
+        repeat=True
+    )
+
+
 def register_404(requests_mock, url):
     requests_mock.get(
         url,
@@ -35,8 +59,19 @@ def register_404(requests_mock, url):
     )
 
 
+def debug_result_exception(result):
+    if result.exception:
+        traceback.print_tb(result.exception.__traceback__)
+        print(type(result.exception))
+        print(str(result.exception))
+        print(result.stdout_bytes.decode('utf8'))
+
+
 # https://github.com/openstax/cnx/issues/291
-def test_utf8_content(tmpdir, requests_mock, datadir):
+def test_utf8_content(tmpdir,
+                      requests_mock,
+                      mock_aioresponses,
+                      datadir):
     # This test is terribly written, but it's because the code...
     out_dir = Path(str(tmpdir))
     base_url = 'https://archive.cnx.org'
@@ -61,16 +96,18 @@ def test_utf8_content(tmpdir, requests_mock, datadir):
         ],
     }
     url = '{}/contents/{}'.format(base_url, node['id'])
-    requests_mock.get(url, json=data)
+    mock_aioresponses.get(url, payload=data)
 
     # Mock the request for the cnxml resource
     with (datadir / 'unicode.cnxml').open('rb') as fb:
         cnxml = fb.read()
     url = '{}/resources/{}'.format(base_url, resource_id)
-    requests_mock.get(url, content=cnxml)
+    mock_aioresponses.get(url, body=cnxml)
 
     # Call the target
-    _write_node(node, base_url, out_dir)
+    loop = asyncio.get_event_loop()
+    coro = _write_contents(node, base_url, out_dir)
+    loop.run_until_complete(coro)
 
     # Verify the content is as specified
     with (datadir / 'unicode.cnxml').open('rb') as fb:
@@ -81,7 +118,12 @@ def test_utf8_content(tmpdir, requests_mock, datadir):
 
 class TestGetCmd:
 
-    def test(self, datadir, tmpcwd, requests_mock, invoker):
+    def test_general(self,
+                     datadir,
+                     tmpcwd,
+                     requests_mock,
+                     mock_aioresponses,
+                     invoker):
         col_id = 'col11405'
         col_version = '1.2'
         col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
@@ -100,23 +142,25 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # Register subcollection/chapter as 404
-        register_404(requests_mock,
-                     'https://archive.cnx.org/contents/'
-                     '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
 
         from nebu.cli.main import cli
         args = ['get', 'test-env', col_id, col_version]
         result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
@@ -130,7 +174,12 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_with_resources(self, datadir, tmpcwd, requests_mock, invoker):
+    def test_with_resources(self,
+                            datadir,
+                            tmpcwd,
+                            requests_mock,
+                            mock_aioresponses,
+                            invoker):
         col_id = 'col11405'
         col_version = '1.2'
         col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
@@ -149,23 +198,25 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # Register subcollection/chapter as 404
-        register_404(requests_mock,
-                     'https://archive.cnx.org/contents/'
-                     '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
 
         from nebu.cli.main import cli
         args = ['get', '--get-resources', 'test-env', col_id, col_version]
         result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
@@ -179,7 +230,12 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_three_part_vers(self, datadir, tmpcwd, monkeypatch, requests_mock,
+    def test_three_part_vers(self,
+                             datadir,
+                             tmpcwd,
+                             monkeypatch,
+                             requests_mock,
+                             mock_aioresponses,
                              invoker):
         col_id = 'col11405'
         col_version = '1.1'
@@ -202,18 +258,19 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # Register subcollection/chapter as 404
-        register_404(requests_mock,
-                     'https://archive.cnx.org/contents/'
-                     '8ddfc8de-5164-5828-9fed-d0ed17edb489@1.1')
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@1.1')
 
         # patch input to return 'y' - getting not-head
         with monkeypatch.context() as m:
@@ -222,6 +279,7 @@ class TestGetCmd:
             args = ['get', 'test-env', col_id, trip_ver]
             result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / '{}_1.{}'.format(col_id, '1.1')
@@ -235,8 +293,13 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_three_part_bad_ver(self, datadir, tmpcwd, monkeypatch,
-                                requests_mock, invoker):
+    def test_three_part_bad_ver(self,
+                                datadir,
+                                tmpcwd,
+                                monkeypatch,
+                                requests_mock,
+                                mock_aioresponses,
+                                invoker):
         col_id = 'col11405'
         col_version = '1.1'
         trip_ver = '1.1.5'
@@ -268,7 +331,12 @@ class TestGetCmd:
         msg = "content unavailable for '{}/{}'".format(col_id, trip_ver)
         assert msg in result.output
 
-    def test_outside_cwd(self, datadir, tmpcwd, monkeypatch, requests_mock,
+    def test_outside_cwd(self,
+                         datadir,
+                         tmpcwd,
+                         monkeypatch,
+                         requests_mock,
+                         mock_aioresponses,
                          invoker):
         monkeypatch.chdir('/var')
         col_id = 'col11405'
@@ -289,24 +357,26 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # Register subcollection/chapter as 404
-        register_404(requests_mock,
-                     'https://archive.cnx.org/contents/'
-                     '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
 
         outdir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
         from nebu.cli.main import cli
         args = ['get', '-d', str(outdir), 'test-env', col_id, col_version]
         result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         outdir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
@@ -320,7 +390,12 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_book_tree(self, datadir, tmpcwd, requests_mock, invoker):
+    def test_book_tree(self,
+                       datadir,
+                       tmpcwd,
+                       requests_mock,
+                       mock_aioresponses,
+                       invoker):
         col_id = 'col11405'
         col_version = '1.2'
         col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
@@ -339,23 +414,25 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # Register subcollection/chapter as 404
-        register_404(requests_mock,
-                     'https://archive.cnx.org/contents/'
-                     '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
 
         from nebu.cli.main import cli
         args = ['get', '-t', 'test-env', col_id, col_version]
         result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
@@ -369,8 +446,13 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_not_latest(self, datadir, tmpcwd, requests_mock,
-                        monkeypatch, invoker):
+    def test_not_latest(self,
+                        datadir,
+                        tmpcwd,
+                        requests_mock,
+                        mock_aioresponses,
+                        monkeypatch,
+                        invoker):
         col_id = 'col11405'
         col_version = '1.1'
         col_latest = '2.1'
@@ -392,13 +474,14 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # patch input to return 'y'
         with monkeypatch.context() as m:
@@ -407,6 +490,7 @@ class TestGetCmd:
             args = ['get', 'test-env', '-d', 'mydir', col_id, col_version]
             result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / 'mydir'
@@ -420,8 +504,13 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_not_latest_tree(self, datadir, tmpcwd, requests_mock,
-                             monkeypatch, invoker):
+    def test_not_latest_tree(self,
+                             datadir,
+                             tmpcwd,
+                             requests_mock,
+                             mock_aioresponses,
+                             monkeypatch,
+                             invoker):
         col_id = 'col11405'
         col_version = '1.1'
         col_latest = '2.1'
@@ -443,13 +532,14 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # patch input to return 'y'
         with monkeypatch.context() as m:
@@ -459,6 +549,7 @@ class TestGetCmd:
                     '-d', 'mydir', col_id, col_version]
             result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / 'mydir'
@@ -472,8 +563,13 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_not_latest_abort(self, datadir, tmpcwd, requests_mock,
-                              monkeypatch, invoker):
+    def test_not_latest_abort(self,
+                              datadir,
+                              tmpcwd,
+                              requests_mock,
+                              mock_aioresponses,
+                              monkeypatch,
+                              invoker):
         col_id = 'col11405'
         col_version = '1.1'
         col_latest = '2.1'
@@ -502,7 +598,12 @@ class TestGetCmd:
         msg = "Non-latest version requested"
         assert msg in result.output
 
-    def test_latest(self, datadir, tmpcwd, requests_mock, invoker):
+    def test_latest(self,
+                    datadir,
+                    tmpcwd,
+                    requests_mock,
+                    mock_aioresponses,
+                    invoker):
         col_id = 'col11405'
         col_version = 'latest'
         col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
@@ -521,23 +622,25 @@ class TestGetCmd:
         resdir = datadir / 'resources'
         for res in resdir.glob('*'):
             url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
-            register_data_file(requests_mock, resdir, res, url)
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
 
         # Register contents
         condir = datadir / 'contents'
         for con in condir.glob('*'):
             url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
             register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
 
         # Register subcollection/chapter as 404
-        register_404(requests_mock,
-                     'https://archive.cnx.org/contents/'
-                     '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
 
         from nebu.cli.main import cli
         args = ['get', 'test-env', col_id, col_version]
         result = invoker(cli, args)
 
+        debug_result_exception(result)
         assert result.exit_code == 0
 
         dir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
@@ -551,7 +654,11 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
-    def test_with_existing_output_dir(self, tmpcwd, invoker, requests_mock,
+    def test_with_existing_output_dir(self,
+                                      tmpcwd,
+                                      invoker,
+                                      requests_mock,
+                                      mock_aioresponses,
                                       datadir):
         col_id = 'col00000'
         col_version = '2.1'
@@ -583,7 +690,10 @@ class TestGetCmd:
 
         assert 'Missing argument "COL_VERSION"' in result.output
 
-    def test_failed_request_using_version(self, requests_mock, invoker):
+    def test_failed_request_using_version(self,
+                                          requests_mock,
+                                          mock_aioresponses,
+                                          invoker):
         col_id = 'col00000'
         col_ver = '1.19'
         content_url = 'https://archive.cnx.org/content/{}/{}'.format(col_id,
@@ -600,7 +710,11 @@ class TestGetCmd:
         msg = "content unavailable for '{}/{}'".format(col_id, col_ver)
         assert msg in result.output
 
-    def test_failed_request_no_raw(self, datadir, requests_mock, invoker):
+    def test_failed_request_no_raw(self,
+                                   datadir,
+                                   requests_mock,
+                                   mock_aioresponses,
+                                   invoker):
         col_id = 'col11405'
         col_version = 'latest'
         col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
@@ -632,7 +746,10 @@ class TestGetCmd:
         msg = "content unavailable for '{}/{}'".format(col_id, col_version)
         assert msg in result.output
 
-    def test_sha1_with_non_utf8_content(self, requests_mock, datadir):
+    def test_sha1_with_non_utf8_content(self,
+                                        requests_mock,
+                                        mock_aioresponses,
+                                        datadir):
         """At one point in time, modules which contained unicode characters
          (used to) get ascii-encoded on dowload, and then we fixed it, but
         this became an issue when detecting files that have changed because
@@ -660,17 +777,19 @@ class TestGetCmd:
             ],
         }
         url = '{}/contents/{}'.format(base_url, node['id'])
-        requests_mock.get(url, json=metadata)
+        mock_aioresponses.get(url, payload=metadata)
 
         with (datadir / 'mod_ascii_encoded.cnxml').open('rb') as fb:
             mod_ascii_encoded = fb.read()
 
         url = '{}/resources/{}'.format(base_url, resource_id)
         # Downloads the ascii-encoded module
-        requests_mock.get(url, content=mod_ascii_encoded)
+        mock_aioresponses.get(url, body=mod_ascii_encoded)
 
         # Call the target
-        _write_node(node, base_url, out_dir)
+        loop = asyncio.get_event_loop()
+        coro = _write_contents(node, base_url, out_dir)
+        loop.run_until_complete(coro)
 
         """ Verify the sha1 is as expected """
         downloaded_hash = get_sha1s_dict(out_dir / legacy_id)["index.cnxml"]

--- a/nebu/tests/conftest.py
+++ b/nebu/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from aioresponses import aioresponses
 from click.testing import CliRunner
 
 
@@ -29,6 +30,12 @@ def invoker():
     """
     runner = CliRunner()
     return runner.invoke
+
+
+@pytest.fixture
+def mock_aioresponses():
+    with aioresponses() as m:
+        yield m
 
 
 @pytest.fixture

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -7,3 +7,4 @@ docker
 pip
 requests
 setuptools
+aiohttp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@ pytest>=4
 pytest-cov
 pytest-runner
 requests-mock
+aioresponses


### PR DESCRIPTION
## description
asyncio is one option we can take to speed up neb get. Brenda is working on using thread pools to do the same thing. We are planning to benchmark the two solutions for fun, learning, and profit for OpenStax.

## note
Passes test for python 3.7 but fails tests for python 3.5 because it uses f-strings. Oops. There was some basic level of care taken to only use python 3.5 compatible asyncio syntax, however.

## commit message
```bash
$ time neb get -r -d "/tmp/neb${RANDOM}" staging col12087 latest
Getting /tmp/neb8141  [###############################]  160/160

real	5m58.370s
user	0m47.899s
sys	0m3.422s

$ git switch async-get

$ time neb get -r -d "/tmp/neb${RANDOM}" staging col12087 latest
Getting /tmp/neb3457  [###############################]  186/186

real	0m17.408s
user	0m7.522s
sys	0m1.023s

$ cd /tmp/neb8141 && find . | sha1sum && cd -
da3348d83ed96604b210eb3a07a0c526b65e6edf  -

$ cd /tmp/neb3457 && find . | sha1sum && cd -
da3348d83ed96604b210eb3a07a0c526b65e6edf  -

$ echo Nice.
Nice.
```

Using asyncio cuts the time needed for a fetch significantly, as can be
seen in the example above using Microbiology. The library `aiohttp` is
used for non-blocking requests and `aioresponses` is used to mock the
responses to `aiohttp` requests similarly to how `requests_mock` does
for the `requests` library. There is some overlapping of mocking in some
of the unit tests for the `/contents/` paths, because the usage of
`requests` was not removed in the initial fetch of the metadata.
Additionally, the `mock_aioresponses` fixture was added to all of the
tests for `neb get` because it intercepts and raises on requests made
that are not mocked.

Another notable change is that the final number in the progress bar has
been changed. This is because progress is now tracked by portion of
json nodes completed rather than by portion of cnxml files completed.
The reason for this was more for semantic clarity and ease of
understanding rather than to yield any functional difference.

When it comes to the `book_tree` option for `neb get`, the bare minimum
was done to maintain passing unit tests. Not too much time was spent on
this because there are already identified issues with the numbering for
this option. See https://github.com/openstax/cnx/issues/324.