### PR TITLE
Upgrade python version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "3.5"
-  - "3.7"
+  - "3.6"
+  - "3.8"
 before_install:
   - make lint
 script:


### PR DESCRIPTION
Couple reasons for this proposal:
- I checked with every CM to confirm they use python>=3.6
- Our dockerfile uses the python3.6 base image
- 3.6 is an objectively more fun number than 3.5
- I like python 3.6 f-strings and it's almost Christmas