### PR TITLE
Stop converting exercise math using mathmlcloud in assemble

### DIFF
--- a/nebu/cli/assemble.py
+++ b/nebu/cli/assemble.py
@@ -16,7 +16,6 @@ from ..utils import relative_path
 
 ASSEMBLED_FILENAME = 'collection.assembled.xhtml'
 DEFAULT_EXERCISES_HOST = 'exercises.openstax.org'
-DEFAULT_MATHMLCLOUD_URL = 'http://mathmlcloud.cnx.org:1337/equation/'
 
 
 def produce_collection_xhtml(binder, output_dir, includes):
@@ -48,11 +47,8 @@ def provide_supporting_files(input_dir, output_dir, binder):
               help='Token for including answers in exercises')
 @click.option('--exercise-host', default=DEFAULT_EXERCISES_HOST,
               help='Default {}'.format(DEFAULT_EXERCISES_HOST))
-@click.option('--mathmlcloud-url', default=DEFAULT_MATHMLCLOUD_URL,
-              help='Default {}'.format(DEFAULT_MATHMLCLOUD_URL))
 @click.pass_context
-def assemble(ctx, input_dir, output_dir, exercise_token, exercise_host,
-             mathmlcloud_url):
+def assemble(ctx, input_dir, output_dir, exercise_token, exercise_host):
     """Assembles litezip structure data into a single-page-html file.
 
     This also stores the intermediary results alongside the resulting
@@ -93,7 +89,7 @@ def assemble(ctx, input_dir, output_dir, exercise_token, exercise_host,
              exercise_host)),
     )
     includes = [exercise_callback_factory(
-        exercise_match, exercise_url, None, exercise_token, mathmlcloud_url)
+        exercise_match, exercise_url, token=exercise_token)
         for exercise_match, exercise_url in exercise_match_urls]
 
     # Write the binder out as a single-page-html


### PR DESCRIPTION
In "neb assemble", we fetch exercises and then try to convert the math
using mathmlcloud.cnx.org.  It makes "neb assemble" very slow when there
are lots of exercises with math, e.g. hsphysics (col10002 on content04).
Since "neb assemble" is part of the bakery CLI, we can just leave the
math until the mathify step instead.  This speeds up "neb assemble" for
hsphysics by more than 50% (from 20m to 9m) on my machine.

---

See also https://github.com/openstax/mathify/pull/54