### PR TITLE
Use 20 threads to fetch exercises in neb assemble

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+9.6.0
+-----
+
+- Neb assemble will now mutlithread exercise fetching (#172)
+
 9.5.1
 -----
 

--- a/nebu/cli/assemble.py
+++ b/nebu/cli/assemble.py
@@ -21,7 +21,7 @@ DEFAULT_EXERCISES_HOST = 'exercises.openstax.org'
 def produce_collection_xhtml(binder, output_dir, includes):
     collection_xhtml = output_dir / ASSEMBLED_FILENAME
     with collection_xhtml.open('wb') as fb:
-        fb.write(bytes(SingleHTMLFormatter(binder, includes)))
+        fb.write(bytes(SingleHTMLFormatter(binder, includes, threads=20)))
 
     return collection_xhtml
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,6 +1,6 @@
 click
 cnxml>=3.0.1
-cnx-epub>=0.18.0
+cnx-epub>=0.21.0
 cnx-litezip>=1.6.0
 cnx-transforms>=1.1.0
 docker


### PR DESCRIPTION
Using 20 threads to fetch exercises for hsphysics (col10002 on
content04) reduces the time in "neb assemble" from 8m26s to 54s.

---

This branch is on top of the remove mathmlcloud PR #168 and depends on the threading code in cnx-epub openstax/cnx-epub#158. **Note: <- travis fails unless this is merged**