### PR TITLE
Add requests limit and adjust timeouts

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+9.5.1
+-----
+
+- Allow a limit to be specified to the number of concurrent requests made (default 8) (#173)
+
 9.5.0
 -----
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Change Log
 -----
 
 - Allow a limit to be specified to the number of concurrent requests made (default 8) (#173)
+- Setting limit to 1 should yield synchronous-like behavior
 
 9.5.0
 -----

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -230,6 +230,63 @@ class TestGetCmd:
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
 
+    def test_with_resources_limit_1_request(self,
+                                            datadir,
+                                            tmpcwd,
+                                            requests_mock,
+                                            mock_aioresponses,
+                                            invoker):
+        col_id = 'col11405'
+        col_version = '1.2'
+        col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
+        col_hash = '{}@{}'.format(col_uuid, '2.1')
+        base_url = 'https://archive.cnx.org'
+        metadata_url = '{}/content/{}/{}'.format(base_url, col_id, col_version)
+        extras_url = '{}/extras/{}'.format(base_url, col_hash)
+
+        # Register the data urls
+        for fname, url in (('contents.json', metadata_url),
+                           ('extras.json', extras_url),
+                           ):
+            register_data_file(requests_mock, datadir, fname, url)
+
+        # Register the resources
+        resdir = datadir / 'resources'
+        for res in resdir.glob('*'):
+            url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
+
+        # Register contents
+        condir = datadir / 'contents'
+        for con in condir.glob('*'):
+            url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
+            register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
+
+        # Register subcollection/chapter as 404
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+
+        from nebu.cli.main import cli
+        args = ['get', '-l', 1, '--get-resources', 'test-env',
+                col_id, col_version]
+        result = invoker(cli, args)
+
+        debug_result_exception(result)
+        assert result.exit_code == 0
+
+        dir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
+        expected = datadir / 'collection_get_resources'
+
+        def _rel(p, b):
+            return p.relative_to(b)
+
+        relative_dir = map(partial(_rel, b=dir), pathlib_walk(dir))
+        relative_expected = map(partial(_rel, b=expected),
+                                pathlib_walk(expected))
+        assert sorted(relative_dir) == sorted(relative_expected)
+
     def test_three_part_vers(self,
                              datadir,
                              tmpcwd,


### PR DESCRIPTION
The default requests limit is 8. Above 8-10, we start to see diminishing
returns from adding more requests concurrently. Timouts were raised,
since we aren't needing to catch server timeouts as frequently.