### PR TITLE
Add flag for saving metadata to get command

### DIFF
--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import traceback
 import asyncio
 import json
+import re
 
 from nebu.cli.get import _write_contents
 from nebu.cli._common import calculate_sha1
@@ -799,7 +800,8 @@ class TestGetCmd:
 
         assert result.exit_code == 2
 
-        assert 'Missing argument "COL_VERSION"' in result.output
+        expected_output = re.compile('Missing argument ["\']COL_VERSION["\']')
+        assert expected_output.search(result.output)
 
     def test_failed_request_using_version(self,
                                           requests_mock,

--- a/nebu/tests/cli/test_get.py
+++ b/nebu/tests/cli/test_get.py
@@ -3,6 +3,7 @@ from os import scandir
 from pathlib import Path
 import traceback
 import asyncio
+import json
 
 from nebu.cli.get import _write_contents
 from nebu.cli._common import calculate_sha1
@@ -286,6 +287,59 @@ class TestGetCmd:
         relative_expected = map(partial(_rel, b=expected),
                                 pathlib_walk(expected))
         assert sorted(relative_dir) == sorted(relative_expected)
+
+    def test_with_metadata(self,
+                           datadir,
+                           tmpcwd,
+                           requests_mock,
+                           mock_aioresponses,
+                           invoker):
+        col_id = 'col11405'
+        col_version = '1.2'
+        col_uuid = 'b699648f-405b-429f-bf11-37bad4246e7c'
+        col_hash = '{}@{}'.format(col_uuid, '2.1')
+        base_url = 'https://archive.cnx.org'
+        metadata_url = '{}/content/{}/{}'.format(base_url, col_id, col_version)
+        extras_url = '{}/extras/{}'.format(base_url, col_hash)
+
+        # Register the data urls
+        for fname, url in (('contents.json', metadata_url),
+                           ('extras.json', extras_url),
+                           ):
+            register_data_file(requests_mock, datadir, fname, url)
+
+        # Register the resources
+        resdir = datadir / 'resources'
+        for res in resdir.glob('*'):
+            url = '{}/resources/{}'.format(base_url, res.relative_to(resdir))
+            register_data_file_aio(mock_aioresponses, resdir, res, url)
+
+        # Register contents
+        condir = datadir / 'contents'
+        for con in condir.glob('*'):
+            url = '{}/contents/{}'.format(base_url, con.relative_to(condir))
+            register_data_file(requests_mock, condir, con, url)
+            register_data_file_aio(mock_aioresponses, condir, con, url)
+
+        # Register subcollection/chapter as 404
+        register_404_aio(mock_aioresponses,
+                         'https://archive.cnx.org/contents/'
+                         '8ddfc8de-5164-5828-9fed-d0ed17edb489@2.1')
+
+        from nebu.cli.main import cli
+        args = ['get', '--save-metadata', 'test-env', col_id, col_version]
+        result = invoker(cli, args)
+
+        debug_result_exception(result)
+        assert result.exit_code == 0
+
+        dir = tmpcwd / '{}_1.{}'.format(col_id, '2.1')
+        metadata_file = dir / 'metadata.json'
+        assert metadata_file.exists()
+
+        metadata_received = json.load(open(metadata_file))
+        metadata_expected = json.load(open(datadir / 'contents.json'))
+        assert metadata_received == metadata_expected
 
     def test_three_part_vers(self,
                              datadir,


### PR DESCRIPTION
The neb get command already uses the legacy url to get a collection's
metadata as part of its processing. This change adds a flag for the
command to save that metadata so that an invoker can utilize that data
if needed.