### PR TITLE
Improvements to better support local VM environments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,12 +44,29 @@ Developer Run
 #. Now you can run various commands:
 
    - ``neb --help`` for help with the various commands
-   
+
 Testing
 -------------
 To run all tests: ``make test``
 
 To run a single test called ``test_main``: ``make test -- -k test_main``
+
+Configuration
+-------------
+
+The CLI will expect (and if not available create a default) configuration file as either ``~/.config/nebuchadnezzar.ini`` or as defined by the ``NEB_CONFIG`` environment variable. You can use this file to configure environment-specific URL values for:
+
+- ``url``: The environment specific URL
+- ``archive_url``: The archive endpoint URL (this is optional, and if not provided the tool will construct the URL based upon convention)
+
+An example of using both of these values to define a ``test`` environment::
+
+    [settings]
+
+    [environ-test]
+    url = https://test.cnx.org
+    archive_url = https://archive.test.cnx.org
+
 
 Configuring an Editor
 =====================

--- a/nebu/cli/_common.py
+++ b/nebu/cli/_common.py
@@ -80,6 +80,17 @@ def get_base_url(context, environ_name):
 
 def build_archive_url(context, environ_name):
     # Build the archive base url
+
+    # We check to see if the archive URL has been specified in the
+    # configuration settings. If so, we'll return that value. Otherwise we'll
+    # fallback to the backwards compatible method of constructing based upon
+    # convention.
+    settings_archive_url = \
+        context.obj['settings']['environs'][environ_name].get('archive_url')
+
+    if settings_archive_url:
+        return settings_archive_url
+
     archive_url = get_base_url(context, environ_name)
     parsed_url = urlparse(archive_url)
     sep = len(parsed_url.netloc.split('.')) > 2 and '-' or '.'

--- a/nebu/cli/ping.py
+++ b/nebu/cli/ping.py
@@ -12,14 +12,20 @@ from ._common import common_params, get_base_url, logger
 @click.argument('env')
 @click.option('-u', '--username', type=str, prompt=True)
 @click.option('-p', '--password', type=str, prompt=True, hide_input=True)
+@click.option('-k', '--insecure', is_flag=True, default=False,
+              help="Ignore SSL certificate verification errors")
 @click.pass_context
-def ping(ctx, env, username, password):
+def ping(ctx, env, username, password, insecure):
     """Check credentials and permission to publish on server"""
     base_url = get_base_url(ctx, env)
 
     auth = HTTPBasicAuth(username, password)
     auth_ping_url = '{}/api/auth-ping'.format(base_url)
-    auth_ping_resp = requests.get(auth_ping_url, auth=auth)
+    auth_ping_resp = requests.get(
+        auth_ping_url,
+        auth=auth,
+        verify=not insecure
+    )
 
     if auth_ping_resp.status_code == 401:
         logger.error('Bad credentials: \n{}'.format(
@@ -32,7 +38,11 @@ def ping(ctx, env, username, password):
         sys.exit(1)
 
     publish_ping_url = '{}/api/publish-ping'.format(base_url)
-    publish_ping_resp = requests.get(publish_ping_url, auth=auth)
+    publish_ping_resp = requests.get(
+        publish_ping_url,
+        auth=auth,
+        verify=not insecure
+    )
 
     if publish_ping_resp.status_code == 401:
         logger.error('Publishing not allowed: \n{}'.format(


### PR DESCRIPTION
While employing neb to work with a cnx stack installed using Vagrant, a couple of issues were found which this PR aims to address:
* Use of commands such as `get`, `publish`, and `ping` fail due to use of self-signed certificates
* The logic to construct archive URLs doesn't work (e.g. neb tries to reach archive-local.cnx.org instead of the desired archive.local.cnx.org)