### PR TITLE
Docker image maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM python:3.7-slim
 
 COPY requirements /tmp/requirements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.7-slim
 
+# Needs to exist for jre installation
+RUN mkdir -p /usr/share/man/man1/
+
+RUN apt update
+RUN apt install -y openjdk-11-jre-headless libmagic1 mime-support
+
 COPY requirements /tmp/requirements
 
 # Install Python Dependencies

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 pretend
-pytest>=4
+pytest>=4.6
 pytest-cov
 pytest-runner
 requests-mock


### PR DESCRIPTION
Docker image size is slimmed from 837MB to 539MB. I also noticed that tests did not pass inside a container, so I added the necessary libraries for neb to function as expected in a container, including a JRE needed for xhtml validation.

Also updated the pytest minimum version because travis will accept nothing less than 4.6 now, it seems.