### PR TITLE
Add fallbacks to pull UUID from CNXML metadata

### DIFF
--- a/nebu/models/binder.py
+++ b/nebu/models/binder.py
@@ -206,3 +206,11 @@ class Binder(BaseBinder):
                 )
                 model.metadata['cnx-archive-uri'] = cnx_archive_uri
                 model.ident_hash = cnx_archive_uri
+        else:
+            # Fallback to trying CNXML for UUID metadata
+            metadata = parse_cnxml_metadata(etree.parse(filepath.open()))
+            uuid = metadata.get('uuid')
+            if uuid:
+                cnx_archive_uri = '{}@'.format(uuid)
+                model.metadata['cnx-archive-uri'] = cnx_archive_uri
+                model.ident_hash = cnx_archive_uri

--- a/nebu/models/utils.py
+++ b/nebu/models/utils.py
@@ -129,6 +129,13 @@ def scan_for_uuid_mapping(start_dir):
                 metadata = json.load(metadata_json)
             uuid = metadata['id']
             mapping[uuid] = filepath
+        else:
+            # Fallback to trying CNXML for UUID metadata
+            metadata = parse_cnxml_metadata(etree.parse(filepath.open()))
+            uuid = metadata.get('uuid')
+            if uuid:
+                mapping[uuid] = filepath
+
     return mapping
 
 

--- a/nebu/tests/data/assembled_collection_for_git_workflow/README.md
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/README.md
@@ -1,0 +1,5 @@
+## Purpose
+
+This assembled collection was GENERATED from `../collection_for_git_workflow`. Please use the `rebuild.py` script in this directory to rebuild/regenerate this content.
+
+If the structure of the assembed content on the file system has changed, please ensure you update `rebuild.py`. Thank you.

--- a/nebu/tests/data/assembled_collection_for_git_workflow/collection.assembled.xhtml
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/collection.assembled.xhtml
@@ -1,0 +1,260 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Introductory Statistics</title>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
+
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
+
+
+    <meta itemprop="dateCreated" content="2013-07-18T19:30:26-05:00"/>
+    <meta itemprop="dateModified" content="2019-02-22T14:15:14.840187-06:00"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introductory Statistics</h1>
+      <span data-type="revised" data-value="2019-02-22T14:15:14.840187-06:00"/>
+      <span data-type="cnx-archive-uri" data-value="30189442-6998-4686-ac05-ed152b91b9de@23.41"/>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="OpenStaxCollege" itemprop="url" data-type="cnx-id">OpenStaxCollege</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+      <div class="publishers">
+        Published By:
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="OpenStaxCollege" itemprop="url" data-type="cnx-id">OpenStaxCollege</a>
+            </span>,             <span id="publisher-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="cnxstats" itemprop="url" data-type="cnx-id">cnxstats</a>
+            </span>      </div>
+      <div class="print-style">
+        Print style:
+        <span data-type="print-style">statistics</span>
+      </div>
+      <div class="permissions">
+        <p class="copyright">
+          Copyright:
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="OpenStaxCollege" itemprop="url" data-type="cnx-id">OpenStaxCollege</a>
+              </span>        </p>
+        <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC BY</a>
+        </p>
+      </div><div itemprop="about" data-type="subject">Mathematics and Statistics</div>    </div>
+
+   <nav id="toc"><ol><li cnx-archive-uri="m47830@1.17"><a href="m47830@1.17.xhtml">Preface</a></li><li><span>Sampling and Data</span><ol><li cnx-archive-uri="d93df8ff-6e4a-4a5e-befc-ba5a144f309c@"><a href="d93df8ff-6e4a-4a5e-befc-ba5a144f309c@.xhtml">Introduction</a></li><li cnx-archive-uri="cb418599-f69b-46c1-b0ef-60d9e36e677f@"><a href="cb418599-f69b-46c1-b0ef-60d9e36e677f@.xhtml">Definitions of Statistics, Probability, and Key Terms</a></li><li cnx-archive-uri="m46885@1.21"><a href="m46885@1.21.xhtml">Data, Sampling, and Variation in Data and Sampling</a></li><li cnx-archive-uri="3fb20c92-9515-420b-ab5e-6de221b89e99@"><a href="3fb20c92-9515-420b-ab5e-6de221b89e99@.xhtml">Frequency, Frequency Tables, and Levels of Measurement</a></li><li cnx-archive-uri="m46919@1.13"><a href="m46919@1.13.xhtml">Experimental Design and Ethics</a></li></ol></li><li><span>Descriptive Statistics</span><ol><li cnx-archive-uri="m46925@1.7"><a href="m46925@1.7.xhtml">Introduction</a></li><li cnx-archive-uri="m46934@1.10"><a href="m46934@1.10.xhtml">Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs</a></li></ol></li><li cnx-archive-uri="m47864@1.17"><a href="m47864@1.17.xhtml">Review Exercises (Ch 3-13)</a></li><li cnx-archive-uri="m47865@1.16"><a href="m47865@1.16.xhtml">Practice Tests (1-4) and Final Exams</a></li><li cnx-archive-uri="m47873@1.9"><a href="m47873@1.9.xhtml">Data Sets</a></li></ol></nav>
+  <div data-type="page" id="m47830@1.17"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Preface</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Preface.
+      </p>
+    </div>
+  </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Sampling and Data</h1>
+      <span data-type="binding" data-value="translucent"/>    </div>
+
+   <h1 data-type="document-title">Sampling and Data</h1><div data-type="page" id="d93df8ff-6e4a-4a5e-befc-ba5a144f309c" class="introduction" data-cnxml-to-html-ver="2.1.0"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introduction to Statistics</h1>
+      <span data-type="revised" data-value="2018/07/24 15:48:58 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="30189442-6998-4686-ac05-ed152b91b9de"/>
+      <span data-type="cnx-archive-uri" data-value="d93df8ff-6e4a-4a5e-befc-ba5a144f309c@"/>
+    </div>
+
+   <div data-type="document-title" id="auto_d93df8ff-6e4a-4a5e-befc-ba5a144f309c_0">Introduction to Statistics</div><cnx-pi data-type="cnx.flag.introduction">
+        class="introduction"
+      </cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="summary" title="Chapter Review"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="formula-review" title="Formula Review"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="practice" title="Practice"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="bring-together-exercises" title="Bringing It Together : Practice"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="free-response" title="Homework"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="bring-together-homework" title="Bringing It Together : Homework"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="references" title="References"</cnx-pi>
+
+
+
+
+
+<figure id="auto_d93df8ff-6e4a-4a5e-befc-ba5a144f309c_fig-ch01_00_01" class="splash"><span data-type="media" id="auto_d93df8ff-6e4a-4a5e-befc-ba5a144f309c_fs-id2354221" data-alt="This photo shows a large open news room with enough space to seat about 200 employees.">
+<img src="CNX_Stats_C01_COs.jpg" data-media-type="image/jpg" alt="This photo shows a large open news room with enough space to seat about 200 employees." width="600" id="auto_d93df8ff-6e4a-4a5e-befc-ba5a144f309c_1"/>
+</span>
+</figure>
+
+
+
+<p id="auto_d93df8ff-6e4a-4a5e-befc-ba5a144f309c_eip-1000">Since you will undoubtedly be given statistical information at some point in your life, you need to know some techniques for analyzing the information thoughtfully. Think about buying a house or managing a budget. Think about your chosen profession.   The fields of economics, business, psychology, education, biology, law, computer science, police science, and early childhood development require at least one course in statistics.</p>
+
+
+  </div><div data-type="page" id="cb418599-f69b-46c1-b0ef-60d9e36e677f" data-cnxml-to-html-ver="2.1.0"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Definitions of Statistics, Probability, and Key Terms</h1>
+      <span data-type="revised" data-value="2018/08/27 16:05:26 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="30189442-6998-4686-ac05-ed152b91b9de"/>
+      <span data-type="cnx-archive-uri" data-value="cb418599-f69b-46c1-b0ef-60d9e36e677f@"/>
+    </div>
+
+   <div data-type="document-title" id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_0">Definitions of Statistics, Probability, and Key Terms</div>
+
+<figure id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_eip-idp25549888"><span data-type="media" id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_id44761709a" data-alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." data-longdesc="m16020_DotPlot_description.html">
+<img src="fig-ch01_02_01n.png" data-media-type="image/png" alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." longdesc="m16020_DotPlot_description.html" width="380" data-longdesc="m16020_DotPlot_description.html" id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_1">
+</img></span>
+</figure>
+
+<p id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_id10326643">Does your dot plot look the same as or different from the example? Why? If you did the same example in an English class with the same number of students, do you think the results would be the same? Why or why not?</p>
+
+<div data-type="glossary" id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_2"><h3 data-type="glossary-title">Glossary</h3>
+<dl id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_average">
+<dt id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_3">Average</dt>
+<dd id="auto_cb418599-f69b-46c1-b0ef-60d9e36e677f_id16316921">also called mean; a number that describes the central tendency of the data</dd>
+</dl>
+</div>
+  </div><div data-type="page" id="m46885@1.21"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Data, Sampling, and Variation in Data and Sampling</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Data, Sampling, and Variation in Data and Sampling.
+      </p>
+    </div>
+  </div><div data-type="page" id="3fb20c92-9515-420b-ab5e-6de221b89e99" data-cnxml-to-html-ver="2.1.0"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Frequency, Frequency Tables, and Levels of Measurement</h1>
+      <span data-type="revised" data-value="2019/02/08 09:37:55.846 US/Central"/>
+      <span data-type="canonical-book-uuid" data-value="30189442-6998-4686-ac05-ed152b91b9de"/>
+      <span data-type="cnx-archive-uri" data-value="3fb20c92-9515-420b-ab5e-6de221b89e99@"/>
+    </div>
+
+   <div data-type="document-title" id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_0">Frequency, Frequency Tables, and Levels of Measurement</div>
+  
+  <p id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_fs-idp5986864">Once you have a set of data, you will need to organize it so that you can analyze how frequently each datum occurs in the set. However, when calculating the frequency, you may need to round your answers so that they are as precise as possible.</p>
+  
+  <figure id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_eip-idp25576880" data-orient="horizontal"><span data-type="media" id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_fs-idm20141232" data-alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1.">
+    <img src="CNX_Stats_C01_M10_003.jpg" data-media-type="image/jpg" alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1." id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_1"/>
+  </span>
+  </figure>
+  
+  <figure id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_eip-idp53333999">
+    <span data-type="media" id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_id9955bb01a" data-alt="Links to a non-existent resource">
+      <img src="foobar.png" data-media-type="image/png" alt="Links to a non-existent resource" id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_2"/>
+    </span>
+  </figure>
+  
+  <p id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_linkexample">
+    There are many ways to grill
+    <a href="/contents/m10275@2.1">a good
+    steak</a>. My favorite can be found
+    <a href="http://en.wikibooks.org/" target="_window">on Wikibooks</a>.
+    <a href="#cb418599-f69b-46c1-b0ef-60d9e36e677f">A link to another page with version</a>
+    <a href="#auto_d93df8ff-6e4a-4a5e-befc-ba5a144f309c_pagelocation">A link to another page with location</a>
+  </p>
+
+
+
+<div data-type="glossary" id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_3"><h3 data-type="glossary-title">Glossary</h3>
+
+  <dl id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_cumrelfreq">
+    <dt id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_4">Cumulative Relative Frequency</dt>
+    <dd id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_id19883082">
+      The term applies to an ordered set of observations from smallest to largest. The cumulative relative frequency is the sum of the relative frequencies for all values that are less than or equal to the given value.
+    </dd>
+  </dl>
+
+
+  <dl id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_freq">
+    <dt id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_5">Frequency</dt>
+    <dd id="auto_3fb20c92-9515-420b-ab5e-6de221b89e99_id19849552">
+   the number of times a value of the data occurs</dd>
+  </dl>
+
+</div>
+  </div><div data-type="page" id="m46919@1.13"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Experimental Design and Ethics</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Experimental Design and Ethics.
+      </p>
+    </div>
+  </div></div><div data-type="chapter"><div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Descriptive Statistics</h1>
+      <span data-type="binding" data-value="translucent"/>    </div>
+
+   <h1 data-type="document-title">Descriptive Statistics</h1><div data-type="page" id="m46925@1.7"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Introduction</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Introduction.
+      </p>
+    </div>
+  </div><div data-type="page" id="m46934@1.10"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs.
+      </p>
+    </div>
+  </div></div><div data-type="page" id="m47864@1.17"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Review Exercises (Ch 3-13)</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Review Exercises (Ch 3-13).
+      </p>
+    </div>
+  </div><div data-type="page" id="m47865@1.16"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Practice Tests (1-4) and Final Exams</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Practice Tests (1-4) and Final Exams.
+      </p>
+    </div>
+  </div><div data-type="page" id="m47873@1.9"><div data-type="metadata">
+      <h1 data-type="document-title" itemprop="name">Data Sets</h1>
+      <span data-type="document" data-value="pointer"/>
+    </div>
+
+    <div>
+      <p>
+        Click <a href="">here</a> to read Data Sets.
+      </p>
+    </div>
+  </div></body>
+</html>

--- a/nebu/tests/data/assembled_collection_for_git_workflow/m46882
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/m46882
@@ -1,0 +1,1 @@
+../collection_for_git_workflow/m46882

--- a/nebu/tests/data/assembled_collection_for_git_workflow/m46882.xhtml
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/m46882.xhtml
@@ -1,0 +1,70 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="None">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Frequency, Frequency Tables, and Levels of Measurement</title>
+    <meta itemprop="inLanguage" data-type="language" content="None"/>
+
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
+
+
+    <meta itemprop="dateCreated" content="None"/>
+    <meta itemprop="dateModified" content="2019/02/08 09:37:55.846 US/Central"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book" data-cnxml-to-html-ver="2.1.0">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Frequency, Frequency Tables, and Levels of Measurement</h1>
+      <span data-type="revised" data-value="2019/02/08 09:37:55.846 US/Central"/>
+      <span data-type="canonical-book-uuid" data-value="30189442-6998-4686-ac05-ed152b91b9de"/>
+      <span data-type="cnx-archive-uri" data-value="m46882@None"/>
+    </div>
+
+   <div data-type="document-title">Frequency, Frequency Tables, and Levels of Measurement</div>
+  
+  <p id="fs-idp5986864">Once you have a set of data, you will need to organize it so that you can analyze how frequently each datum occurs in the set. However, when calculating the frequency, you may need to round your answers so that they are as precise as possible.</p>
+  
+  <figure id="eip-idp25576880" data-orient="horizontal"><span data-type="media" id="fs-idm20141232" data-alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1.">
+    <img src="CNX_Stats_C01_M10_003.jpg" data-media-type="image/jpg" alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1."/>
+  </span>
+  </figure>
+  
+  <figure id="eip-idp53333999">
+    <span data-type="media" id="id9955bb01a" data-alt="Links to a non-existent resource">
+      <img src="foobar.png" data-media-type="image/png" alt="Links to a non-existent resource"/>
+    </span>
+  </figure>
+  
+  <p id="linkexample">
+    There are many ways to grill
+    <a href="/m10275@2.1">a good
+    steak</a>. My favorite can be found
+    <a href="http://en.wikibooks.org/" target="_window">on Wikibooks</a>.
+    <a href="/m46909@1.12">A link to another page with version</a>
+    <a href="/m46913#pagelocation">A link to another page with location</a>
+  </p>
+
+
+
+<div data-type="glossary"><h3 data-type="glossary-title">Glossary</h3>
+
+  <dl id="cumrelfreq">
+    <dt>Cumulative Relative Frequency</dt>
+    <dd id="id19883082">
+      The term applies to an ordered set of observations from smallest to largest. The cumulative relative frequency is the sum of the relative frequencies for all values that are less than or equal to the given value.
+    </dd>
+  </dl>
+
+
+  <dl id="freq">
+    <dt>Frequency</dt>
+    <dd id="id19849552">
+   the number of times a value of the data occurs</dd>
+  </dl>
+
+</div>
+  </body>
+</html>

--- a/nebu/tests/data/assembled_collection_for_git_workflow/m46909
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/m46909
@@ -1,0 +1,1 @@
+../collection_for_git_workflow/m46909

--- a/nebu/tests/data/assembled_collection_for_git_workflow/m46909.xhtml
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/m46909.xhtml
@@ -1,0 +1,42 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="None">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Definitions of Statistics, Probability, and Key Terms</title>
+    <meta itemprop="inLanguage" data-type="language" content="None"/>
+
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
+
+
+    <meta itemprop="dateCreated" content="None"/>
+    <meta itemprop="dateModified" content="2018/08/27 16:05:26 -0500"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book" data-cnxml-to-html-ver="2.1.0">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Definitions of Statistics, Probability, and Key Terms</h1>
+      <span data-type="revised" data-value="2018/08/27 16:05:26 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="30189442-6998-4686-ac05-ed152b91b9de"/>
+      <span data-type="cnx-archive-uri" data-value="m46909@None"/>
+    </div>
+
+   <div data-type="document-title">Definitions of Statistics, Probability, and Key Terms</div>
+
+<figure id="eip-idp25549888"><span data-type="media" id="id44761709a" data-alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." data-longdesc="m16020_DotPlot_description.html">
+<img src="fig-ch01_02_01n.png" data-media-type="image/png" alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." longdesc="m16020_DotPlot_description.html" width="380" data-longdesc="m16020_DotPlot_description.html">
+</img></span>
+</figure>
+
+<p id="id10326643">Does your dot plot look the same as or different from the example? Why? If you did the same example in an English class with the same number of students, do you think the results would be the same? Why or why not?</p>
+
+<div data-type="glossary"><h3 data-type="glossary-title">Glossary</h3>
+<dl id="average">
+<dt>Average</dt>
+<dd id="id16316921">also called mean; a number that describes the central tendency of the data</dd>
+</dl>
+</div>
+  </body>
+</html>

--- a/nebu/tests/data/assembled_collection_for_git_workflow/m46913
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/m46913
@@ -1,0 +1,1 @@
+../collection_for_git_workflow/m46913

--- a/nebu/tests/data/assembled_collection_for_git_workflow/m46913.xhtml
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/m46913.xhtml
@@ -1,0 +1,59 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="None">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+
+    <title>Introduction to Statistics</title>
+    <meta itemprop="inLanguage" data-type="language" content="None"/>
+
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
+
+
+    <meta itemprop="dateCreated" content="None"/>
+    <meta itemprop="dateModified" content="2018/07/24 15:48:58 -0500"/>
+  </head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book" class="introduction" data-cnxml-to-html-ver="2.1.0">
+    <div data-type="metadata" style="display: none;">
+      <h1 data-type="document-title" itemprop="name">Introduction to Statistics</h1>
+      <span data-type="revised" data-value="2018/07/24 15:48:58 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="30189442-6998-4686-ac05-ed152b91b9de"/>
+      <span data-type="cnx-archive-uri" data-value="m46913@None"/>
+    </div>
+
+   <div data-type="document-title">Introduction to Statistics</div><cnx-pi data-type="cnx.flag.introduction">
+        class="introduction"
+      </cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="summary" title="Chapter Review"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="formula-review" title="Formula Review"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="practice" title="Practice"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="bring-together-exercises" title="Bringing It Together : Practice"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="free-response" title="Homework"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="bring-together-homework" title="Bringing It Together : Homework"</cnx-pi>
+
+<cnx-pi data-type="cnx.eoc">class="references" title="References"</cnx-pi>
+
+
+
+
+
+<figure id="fig-ch01_00_01" class="splash"><span data-type="media" id="fs-id2354221" data-alt="This photo shows a large open news room with enough space to seat about 200 employees.">
+<img src="CNX_Stats_C01_COs.jpg" data-media-type="image/jpg" alt="This photo shows a large open news room with enough space to seat about 200 employees." width="600"/>
+</span>
+</figure>
+
+
+
+<p id="eip-1000">Since you will undoubtedly be given statistical information at some point in your life, you need to know some techniques for analyzing the information thoughtfully. Think about buying a house or managing a budget. Think about your chosen profession.   The fields of economics, business, psychology, education, biology, law, computer science, police science, and early childhood development require at least one course in statistics.</p>
+
+
+  </body>
+</html>

--- a/nebu/tests/data/assembled_collection_for_git_workflow/rebuild.py
+++ b/nebu/tests/data/assembled_collection_for_git_workflow/rebuild.py
@@ -1,0 +1,40 @@
+""" This script rebuilds the contents of this directory """
+from pathlib import Path
+
+from cnxepub import formatters
+from nebu.models.binder import Binder
+from nebu.models.document import Document
+from nebu.tests.models.test_document import mock_reference_resolver
+from nebu.utils import relative_path
+
+
+input_dir = Path('../collection_for_git_workflow')
+output_dir = Path('.')
+
+
+def main():
+    # Transform the modules from cnxml to html
+    for id in ('m46882', 'm46909', 'm46913'):
+        filepath = input_dir / id / 'index.cnxml'
+        doc = Document.from_index_cnxml(filepath, mock_reference_resolver)
+
+        # Write the html to file
+        html_filepath = (output_dir / '{}.xhtml'.format(id))
+        html_filepath.unlink()
+        with html_filepath.open('wb') as fb:
+            fb.write(bytes(formatters.HTMLFormatter(doc)))
+
+        # Create a symbolic link back to the module's source directory
+        link_to_source_dir = output_dir / id
+        link_to_source_dir.unlink()
+        source_dir = input_dir / id
+        link_to_source_dir.symlink_to(relative_path(source_dir, output_dir))
+
+    # Create the single-page-html
+    binder = Binder.from_collection_xml(input_dir / 'collection.xml')
+    with (output_dir / 'collection.assembled.xhtml').open('wb') as fb:
+        fb.write(bytes(formatters.SingleHTMLFormatter(binder)))
+
+
+if __name__ == '__main__':
+    main()

--- a/nebu/tests/data/collection_for_git_workflow/README.md
+++ b/nebu/tests/data/collection_for_git_workflow/README.md
@@ -1,0 +1,7 @@
+## Purpose
+
+This collection was created for the purpose of testing the workflow using git storage data: cnxml -> html -> single-html.
+
+Please do add elements to this test data if they fit into the git storage workflow.
+
+Note, this content is used to generate the content in `../assembled_collection_for_git_workflow`. If you make changes here, please see the [README](../assembled_collection_for_git_workflow) in that directory for instructions.

--- a/nebu/tests/data/collection_for_git_workflow/collection.xml
+++ b/nebu/tests/data/collection_for_git_workflow/collection.xml
@@ -1,0 +1,90 @@
+<col:collection xmlns="http://cnx.rice.edu/collxml" xmlns:cnx="http://cnx.rice.edu/cnxml" xmlns:cnxorg="http://cnx.rice.edu/system-info" xmlns:md="http://cnx.rice.edu/mdml" xmlns:col="http://cnx.rice.edu/collxml" xml:lang="en">
+  <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+    <!-- WARNING! The 'metadata' section is read only. Do not edit below. Changes to the metadata section in the source will not be saved. -->
+    <md:repository>https://legacy.cnx.org/content</md:repository>
+    <md:content-url>https://legacy.cnx.org/content/col11562/1.23</md:content-url>
+    <md:content-id>col11562</md:content-id>
+    <md:title>Introductory Statistics</md:title>
+    <md:version>1.23</md:version>
+    <md:created>2013-07-18T19:30:26-05:00</md:created>
+    <md:revised>2019-02-22T14:15:14.840187-06:00</md:revised>
+    <md:language>en</md:language>
+    <md:license url="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License</md:license>
+    <!-- For information on license requirements for use or modification, see license url in the above <md:license> element.
+           For information on formatting required attribution, see the URL:
+             CONTENT_URL/content_info#cnx_cite_header
+           where CONTENT_URL is the value provided above in the <md:content-url> element.
+      -->
+    <md:actors>
+      <md:person userid="cnxstats">
+        <md:firstname>OpenStax</md:firstname>
+        <md:surname>Statistics</md:surname>
+        <md:fullname>OpenStax College</md:fullname>
+        <md:email>info@openstaxcollege.org</md:email>
+      </md:person>
+      <md:person userid="OpenStaxCollege">
+        <md:firstname/>
+        <md:surname>OpenStax College</md:surname>
+        <md:fullname>OpenStax</md:fullname>
+        <md:email>info@openstaxcollege.org</md:email>
+      </md:person>
+    </md:actors>
+    <md:roles>
+      <md:role type="author">OpenStaxCollege</md:role>
+      <md:role type="maintainer">OpenStaxCollege cnxstats</md:role>
+      <md:role type="licensor">OpenStaxCollege</md:role>
+    </md:roles>
+    <md:abstract/>
+    <md:subjectlist>
+      <md:subject>Mathematics and Statistics</md:subject>
+    </md:subjectlist>
+  </metadata>
+  <col:parameters>
+    <col:param name="print-style" value="statistics"/>
+  </col:parameters>
+  <col:content>
+    <col:module document="m47830" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.17">
+      <md:title>Preface</md:title>
+    </col:module>
+    <col:subcollection>
+      <md:title>Sampling and Data</md:title>
+      <col:content>
+        <col:module document="m46913" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.13">
+          <md:title>Introduction</md:title>
+        </col:module>
+        <col:module document="m46909" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.12">
+          <md:title>Definitions of Statistics, Probability, and Key Terms</md:title>
+        </col:module>
+        <col:module document="m46885" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.21">
+          <md:title>Data, Sampling, and Variation in Data and Sampling</md:title>
+        </col:module>
+        <col:module document="m46882" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.17">
+          <md:title>Frequency, Frequency Tables, and Levels of Measurement</md:title>
+        </col:module>
+        <col:module document="m46919" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.13">
+          <md:title>Experimental Design and Ethics</md:title>
+        </col:module>
+      </col:content>
+    </col:subcollection>
+    <col:subcollection>
+      <md:title>Descriptive Statistics</md:title>
+      <col:content>
+        <col:module document="m46925" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.7">
+          <md:title>Introduction</md:title>
+        </col:module>
+        <col:module document="m46934" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.10">
+          <md:title>Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs</md:title>
+        </col:module>
+      </col:content>
+    </col:subcollection>
+    <col:module document="m47864" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.17">
+      <md:title>Review Exercises (Ch 3-13)</md:title>
+    </col:module>
+    <col:module document="m47865" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.16">
+      <md:title>Practice Tests (1-4) and Final Exams</md:title>
+    </col:module>
+    <col:module document="m47873" version="latest" repository="https://legacy.cnx.org/content" cnxorg:version-at-this-collection-version="1.9">
+      <md:title>Data Sets</md:title>
+    </col:module>
+  </col:content>
+</col:collection>

--- a/nebu/tests/data/collection_for_git_workflow/m46882/index.cnxml
+++ b/nebu/tests/data/collection_for_git_workflow/m46882/index.cnxml
@@ -1,0 +1,51 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:cnxorg="http://cnx.rice.edu/system-info" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:md="http://cnx.rice.edu/mdml" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:bib="http://bibtexml.sf.net/" id="id5564559" module-id="" cnxml-version="0.7">
+  <title>Frequency, Frequency Tables, and Levels of Measurement</title>
+  <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <md:content-id>m46882</md:content-id>
+  <md:title>Frequency, Frequency Tables, and Levels of Measurement</md:title>
+  <md:uuid>3fb20c92-9515-420b-ab5e-6de221b89e99</md:uuid>
+  <md:canonical-book-uuid>30189442-6998-4686-ac05-ed152b91b9de</md:canonical-book-uuid>
+  <md:revised>2019/02/08 09:37:55.846 US/Central</md:revised>
+</metadata>
+
+<content>
+  <para id="fs-idp5986864">Once you have a set of data, you will need to organize it so that you can analyze how frequently each datum occurs in the set. However, when calculating the frequency, you may need to round your answers so that they are as precise as possible.</para>
+  <figure xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" id="eip-idp25576880" orient="horizontal"><media id="fs-idm20141232" alt="Graph A is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows the relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 0.27. Graph B is a bar graph with 7 bars. The x-axis shows CEO's ages in intervals of 5 years starting with 40 - 44. The y-axis shows relative frequency in intervals of 0.2 from 0 - 1. The highest relative frequency shown is 1.">
+    <image mime-type="image/jpg" src="CNX_Stats_C01_M10_003.jpg"/>
+  </media>
+  </figure>
+  <figure id="eip-idp53333999">
+    <media id="id9955bb01a" alt="Links to a non-existent resource">
+      <image src="foobar.png" mime-type="image/png"/>
+    </media>
+  </figure>
+  <para id="linkexample">
+    There are many ways to grill
+    <link document="m10275" version="2.1">a good
+    steak</link>. My favorite can be found
+    <link url="http://en.wikibooks.org/"
+          window="new">on Wikibooks</link>.
+    <link document="m46909" version="1.12">A link to another page with version</link>
+    <link document="m46913" target-id="pagelocation">A link to another page with location</link>
+  </para>
+
+</content>
+
+<glossary>
+
+  <definition id="cumrelfreq">
+    <term>Cumulative Relative Frequency</term>
+    <meaning id="id19883082">
+      The term applies to an ordered set of observations from smallest to largest. The cumulative relative frequency is the sum of the relative frequencies for all values that are less than or equal to the given value.
+    </meaning>
+  </definition>
+
+
+  <definition id="freq">
+    <term>Frequency</term>
+    <meaning id="id19849552">
+   the number of times a value of the data occurs</meaning>
+  </definition>
+
+</glossary>
+</document>

--- a/nebu/tests/data/collection_for_git_workflow/m46909/index.cnxml
+++ b/nebu/tests/data/collection_for_git_workflow/m46909/index.cnxml
@@ -1,0 +1,24 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:cnxorg="http://cnx.rice.edu/system-info" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:md="http://cnx.rice.edu/mdml" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:bib="http://bibtexml.sf.net/" id="id6723023" module-id="" cnxml-version="0.7">
+  <title>Definitions of Statistics, Probability, and Key Terms</title>
+  <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <md:content-id>m46909</md:content-id>
+  <md:title>Definitions of Statistics, Probability, and Key Terms</md:title>
+  <md:uuid>cb418599-f69b-46c1-b0ef-60d9e36e677f</md:uuid>
+  <md:canonical-book-uuid>30189442-6998-4686-ac05-ed152b91b9de</md:canonical-book-uuid>
+  <md:revised>2018/08/27 16:05:26 -0500</md:revised>
+</metadata>
+
+<content>
+<figure id="eip-idp25549888"><media id="id44761709a" alt="This is a dot plot showing average hours of sleep. The number line is marked in intervals of 1 from 5 to 9. Dots above the line show 1 person reporting 5 hours, 1 with 5.5, 3 with 6, 4 with 6.5, 2 with 7, 2 with 8, and 1 with 9 hours." longdesc="m16020_DotPlot_description.html">
+<image src="fig-ch01_02_01n.png" mime-type="image/png" width="380">
+<param name="longdesc" value="m16020_DotPlot_description.html"/></image></media>
+</figure>
+<para id="id10326643">Does your dot plot look the same as or different from the example? Why? If you did the same example in an English class with the same number of students, do you think the results would be the same? Why or why not?</para>
+</content>
+<glossary>
+<definition id="average">
+<term>Average</term>
+<meaning id="id16316921">also called mean; a number that describes the central tendency of the data</meaning>
+</definition>
+</glossary>
+</document>

--- a/nebu/tests/data/collection_for_git_workflow/m46913/index.cnxml
+++ b/nebu/tests/data/collection_for_git_workflow/m46913/index.cnxml
@@ -1,0 +1,28 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:cnxorg="http://cnx.rice.edu/system-info" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:md="http://cnx.rice.edu/mdml" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:bib="http://bibtexml.sf.net/" id="new" module-id="" cnxml-version="0.7" class="introduction">
+    <title>Introduction to Statistics</title>
+    <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <md:content-id>m46913</md:content-id>
+  <md:title>Introduction to Statistics</md:title>
+  <md:uuid>d93df8ff-6e4a-4a5e-befc-ba5a144f309c</md:uuid>
+  <md:canonical-book-uuid>30189442-6998-4686-ac05-ed152b91b9de</md:canonical-book-uuid>
+  <md:revised>2018/07/24 15:48:58 -0500</md:revised>
+</metadata>
+
+<content>
+<?cnx.eoc class="summary" title="Chapter Review"?>
+<?cnx.eoc class="formula-review" title="Formula Review"?>
+<?cnx.eoc class="practice" title="Practice"?>
+<?cnx.eoc class="bring-together-exercises" title="Bringing It Together : Practice"?>
+<?cnx.eoc class="free-response" title="Homework"?>
+<?cnx.eoc class="bring-together-homework" title="Bringing It Together : Homework"?>
+<?cnx.eoc class="references" title="References"?>
+
+
+<figure id="fig-ch01_00_01" class="splash"><media id="fs-id2354221" alt="This photo shows a large open news room with enough space to seat about 200 employees.">
+<image mime-type="image/jpg" src="CNX_Stats_C01_COs.jpg" width="600"/>
+</media>
+</figure>
+
+<para id="eip-1000">Since you will undoubtedly be given statistical information at some point in your life, you need to know some techniques for analyzing the information thoughtfully. Think about buying a house or managing a budget. Think about your chosen profession.   The fields of economics, business, psychology, education, biology, law, computer science, police science, and early childhood development require at least one course in statistics.</para>
+</content>
+</document>

--- a/nebu/tests/data/collection_for_git_workflow/metadata.json
+++ b/nebu/tests/data/collection_for_git_workflow/metadata.json
@@ -1,0 +1,4873 @@
+{
+    "googleAnalytics": [
+        "UA-30227798-6",
+        "UA-101537094-1"
+    ],
+    "version": "23.41",
+    "submitlog": "errata 10759",
+    "abstract": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:c=\"http://cnx.rice.edu/cnxml\" xmlns:md=\"http://cnx.rice.edu/mdml\" xmlns:qml=\"http://cnx.rice.edu/qml/1.0\" xmlns:mod=\"http://cnx.rice.edu/#moduleIds\" xmlns:bib=\"http://bibtexml.sf.net/\" xmlns:data=\"http://www.w3.org/TR/html5/dom.html#custom-data-attribute\" data-cnxml-to-html-ver=\"1.3.2\"/>",
+    "revised": "2020-01-10T19:53:03Z",
+    "printStyle": "statistics",
+    "roles": null,
+    "keywords": [],
+    "id": "30189442-6998-4686-ac05-ed152b91b9de",
+    "canonical": null,
+    "title": "Introductory Statistics",
+    "mediaType": "application/vnd.org.cnx.collection",
+    "canon_url": "https://cnx.org/contents/30189442-6998-4686-ac05-ed152b91b9de/Introductory-Statistics",
+    "subjects": [
+        "Mathematics and Statistics"
+    ],
+    "legacy_id": "col11562",
+    "parentId": null,
+    "resources": [
+        {
+            "media_type": "text/xml",
+            "id": "d51da6deb84cb4a8ab65a7339a93d3cc72098399",
+            "filename": "collection.xml"
+        }
+    ],
+    "publishers": [
+        {
+            "surname": "OpenStax College",
+            "suffix": "",
+            "firstname": "",
+            "title": "",
+            "fullname": "OpenStax",
+            "id": "OpenStaxCollege"
+        },
+        {
+            "surname": "Statistics",
+            "suffix": "",
+            "firstname": "OpenStax",
+            "title": "",
+            "fullname": "OpenStax College",
+            "id": "cnxstats"
+        }
+    ],
+    "parent": {
+        "authors": [],
+        "shortId": null,
+        "version": "",
+        "id": null,
+        "title": null
+    },
+    "stateid": 1,
+    "parentTitle": null,
+    "shortId": "MBiUQmmY",
+    "authors": [
+        {
+            "surname": "OpenStax College",
+            "suffix": "",
+            "firstname": "",
+            "title": "",
+            "fullname": "OpenStax",
+            "id": "OpenStaxCollege"
+        }
+    ],
+    "parentVersion": "",
+    "legacy_version": "1.23",
+    "licensors": [
+        {
+            "surname": "OpenStax College",
+            "suffix": "",
+            "firstname": "",
+            "title": "",
+            "fullname": "OpenStax",
+            "id": "OpenStaxCollege"
+        }
+    ],
+    "language": "en",
+    "license": {
+        "url": "http://creativecommons.org/licenses/by/4.0/",
+        "code": "by",
+        "version": "4.0",
+        "name": "Creative Commons Attribution License"
+    },
+    "created": "2013-07-19T00:30:26Z",
+    "tree": {
+        "shortId": "MBiUQmmY@23.41",
+        "title": "Introductory Statistics",
+        "id": "30189442-6998-4686-ac05-ed152b91b9de@23.41",
+        "contents": [
+            {
+                "shortId": "kcV4GRqc@17",
+                "title": "Preface",
+                "id": "91c57819-1a9c-42a4-afb6-c00a6de8d085@17",
+                "slug": null
+            },
+            {
+                "shortId": "x35NyANm@23.40",
+                "title": "Sampling and Data",
+                "id": "c77e4dc8-0366-54b8-a9f3-cbc613fcc61e@23.40",
+                "contents": [
+                    {
+                        "shortId": "2T34_25K@14",
+                        "title": "Introduction",
+                        "id": "d93df8ff-6e4a-4a5e-befc-ba5a144f309c@14",
+                        "slug": null
+                    },
+                    {
+                        "shortId": "y0GFmfab@12",
+                        "title": "Definitions of Statistics, Probability, and Key Terms",
+                        "id": "cb418599-f69b-46c1-b0ef-60d9e36e677f@12",
+                        "slug": null
+                    },
+                    {
+                        "shortId": "CY4aJuYS@22",
+                        "title": "Data, Sampling, and Variation in Data and Sampling",
+                        "id": "098e1a26-e612-4449-a45e-80fa23feba02@22",
+                        "slug": null
+                    },
+                    {
+                        "shortId": "P7IMkpUV@17",
+                        "title": "Frequency, Frequency Tables, and Levels of Measurement",
+                        "id": "3fb20c92-9515-420b-ab5e-6de221b89e99@17",
+                        "slug": null
+                    },
+                    {
+                        "shortId": "Ph_ExrCQ@13",
+                        "title": "Experimental Design and Ethics",
+                        "id": "3e1fc4c6-b090-47c1-8170-8578198cc3f0@13",
+                        "slug": null
+                    }
+                ],
+                "slug": null
+            },
+            {
+                "shortId": "h5wVkFeV@23.40",
+                "title": "Descriptive Statistics",
+                "id": "879c1590-5795-5870-aca4-59086b351595@23.40",
+                "contents": [
+                    {
+                        "shortId": "Z_8PEIhn@7",
+                        "title": "Introduction",
+                        "id": "67ff0f10-8867-4852-85f6-0f0be2257ed4@7",
+                        "slug": null
+                    },
+                    {
+                        "shortId": "KFOdKxbi@10",
+                        "title": "Stem-and-Leaf Graphs (Stemplots), Line Graphs, and Bar Graphs",
+                        "id": "28539d2b-16e2-4356-9ba8-9fcceaa27765@10",
+                        "slug": null
+                    }
+                ],
+                "slug": null
+            },
+            {
+                "shortId": "YhmlJ_b-@17",
+                "title": "Review Exercises (Ch 3-13)",
+                "id": "6219a527-f6fe-4172-9a4c-fc4d625483fa@17",
+                "slug": null
+            },
+            {
+                "shortId": "kIxIs3X-@16",
+                "title": "Practice Tests (1-4) and Final Exams",
+                "id": "908c48b3-75fe-403d-98ef-9e68c3150587@16",
+                "slug": null
+            },
+            {
+                "shortId": "PvgwvFJH@9",
+                "title": "Data Sets",
+                "id": "3ef830bc-5247-460a-9007-e3fd762e5e93@9",
+                "slug": null
+            }
+        ],
+        "slug": null
+    },
+    "doctype": "",
+    "buyLink": null,
+    "submitter": {
+        "surname": "OpenStax College",
+        "suffix": "",
+        "firstname": "",
+        "title": "",
+        "fullname": "OpenStax",
+        "id": "OpenStaxCollege"
+    },
+    "collated": false,
+    "baked": "2020-01-10T13:53:21.072459-06:00",
+    "parentAuthors": [],
+    "history": [
+        {
+            "changes": "errata 10759",
+            "version": "23.41",
+            "revised": "2020-01-10T19:53:03Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "errata 10754 10753 10752 10751 10639 9866 9628 9500 9479 9392 9378 9377 9345 9306 9292 9289 9266 9265 9256 9249 9248 9245 9238 9230",
+            "version": "23.40",
+            "revised": "2020-01-10T19:23:08Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "errata 9237",
+            "version": "23.39",
+            "revised": "2020-01-10T18:13:34Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "errata 9236",
+            "version": "23.38",
+            "revised": "2020-01-10T18:01:06Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "errata 10117",
+            "version": "23.37",
+            "revised": "2020-01-10T17:52:47Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "errata 8762",
+            "version": "23.36",
+            "revised": "2020-01-10T17:44:43Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "errata 8762",
+            "version": "23.35",
+            "revised": "2020-01-10T17:30:13Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "implementing errata - CP",
+            "version": "23.34",
+            "revised": "2019-12-02T19:22:16Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "Errata# 9291 -MJ",
+            "version": "23.33",
+            "revised": "2019-08-23T19:10:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata 9269",
+            "version": "23.32",
+            "revised": "2019-08-21T16:44:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "removing subfigures from objects to resolve placement issue in webview ",
+            "version": "23.31",
+            "revised": "2019-06-17T14:07:41Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "test publishing",
+            "version": "23.30",
+            "revised": "2019-05-13T15:18:05Z",
+            "publisher": {
+                "surname": "otto",
+                "suffix": null,
+                "firstname": "zumi",
+                "title": "",
+                "fullname": "zumi otto",
+                "id": "zumi"
+            }
+        },
+        {
+            "changes": "errata 8483",
+            "version": "23.29",
+            "revised": "2019-04-24T18:37:00Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "12.6 trying to fix note, removed the note from being nested in a para tag - CP",
+            "version": "23.28",
+            "revised": "2019-03-14T16:32:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "attempting to fix note for issue 306 - CP",
+            "version": "23.27",
+            "revised": "2019-03-14T16:25:50Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "still trying to fix note - CP",
+            "version": "23.26",
+            "revised": "2019-03-14T16:15:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fixing notes in 10.1 - CP",
+            "version": "23.25",
+            "revised": "2019-03-14T16:11:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fixed note in 12.6 - CP",
+            "version": "23.24",
+            "revised": "2019-03-14T16:04:03Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "resolving more note issues ",
+            "version": "23.23",
+            "revised": "2019-03-14T15:56:21Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "making fixes to a couple of note elements | CP",
+            "version": "23.22",
+            "revised": "2019-03-14T15:22:50Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "removed a note per issue 647  -CP",
+            "version": "23.21",
+            "revised": "2019-03-07T16:40:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "moved some tables into examples - cp ",
+            "version": "23.20",
+            "revised": "2019-02-26T16:57:40Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "adding exercise 10.7 solution back - CP",
+            "version": "23.19",
+            "revised": "2019-02-22T20:15:14Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "erratum 6898 | CP",
+            "version": "23.18",
+            "revised": "2019-02-19T18:55:59Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "erratum 5953 | CP",
+            "version": "23.17",
+            "revised": "2019-02-19T18:02:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "erratum 6135 | CP",
+            "version": "23.16",
+            "revised": "2019-02-19T17:51:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata 6682 | CP",
+            "version": "23.15",
+            "revised": "2019-02-19T17:09:49Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata 6838 | CP",
+            "version": "23.14",
+            "revised": "2019-02-19T16:44:41Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "erratum 7786 | CP",
+            "version": "23.13",
+            "revised": "2019-02-18T14:52:03Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "removed extra breaks to resolve zen 251 | CP",
+            "version": "23.12",
+            "revised": "2019-02-08T15:37:54Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "making notes look like they should | CP",
+            "version": "23.11",
+            "revised": "2019-02-08T15:26:36Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Adding note title to resolve zen 294 | CP",
+            "version": "23.10",
+            "revised": "2019-02-08T15:24:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.9",
+            "revised": "2018-11-12T22:08:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.8",
+            "revised": "2018-11-12T21:45:54Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.7",
+            "revised": "2018-11-12T21:42:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.6",
+            "revised": "2018-11-12T21:36:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.5",
+            "revised": "2018-11-12T21:28:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.4",
+            "revised": "2018-11-12T21:15:54Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.3",
+            "revised": "2018-11-12T21:13:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "class=\"appendix\"",
+            "version": "23.2",
+            "revised": "2018-11-12T20:58:09Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "bake",
+            "version": "23.1",
+            "revised": "2018-09-26T16:24:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "move footnote",
+            "version": "22.8",
+            "revised": "2018-09-17T20:19:38Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "remove footnote",
+            "version": "22.7",
+            "revised": "2018-09-17T19:50:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "unnest calculator note",
+            "version": "22.6",
+            "revised": "2018-09-12T21:14:35Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix appendix class",
+            "version": "22.5",
+            "revised": "2018-09-12T21:04:10Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix lists",
+            "version": "22.4",
+            "revised": "2018-09-12T20:58:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "put code into para",
+            "version": "22.3",
+            "revised": "2018-09-12T20:51:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix image next to graph",
+            "version": "22.2",
+            "revised": "2018-09-07T21:15:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": " remove display block in math",
+            "version": "22.1",
+            "revised": "2018-09-06T21:52:56Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "remove display block math",
+            "version": "21.21",
+            "revised": "2018-09-06T21:08:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "display block remove",
+            "version": "21.20",
+            "revised": "2018-09-06T21:03:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "remove display block",
+            "version": "21.19",
+            "revised": "2018-09-06T20:51:06Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 267 -MJ ",
+            "version": "21.18",
+            "revised": "2018-09-06T20:50:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "block",
+            "version": "21.17",
+            "revised": "2018-09-06T20:47:35Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "remove inline math",
+            "version": "21.16",
+            "revised": "2018-09-06T20:29:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 267 -MJ",
+            "version": "21.15",
+            "revised": "2018-09-06T20:27:37Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 267 -MJ",
+            "version": "21.14",
+            "revised": "2018-09-06T20:09:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 267 -MJ",
+            "version": "21.13",
+            "revised": "2018-09-06T19:35:50Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 267 -MJ",
+            "version": "21.12",
+            "revised": "2018-08-31T15:51:39Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 265 -MJ",
+            "version": "21.11",
+            "revised": "2018-08-31T15:20:42Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Errata# 262 -MJ",
+            "version": "21.10",
+            "revised": "2018-08-30T20:21:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 248 -MJ",
+            "version": "21.9",
+            "revised": "2018-08-29T23:22:44Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 264 -MJ",
+            "version": "21.8",
+            "revised": "2018-08-29T22:46:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "list",
+            "version": "21.7",
+            "revised": "2018-08-27T21:05:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix note",
+            "version": "21.6",
+            "revised": "2018-08-27T20:53:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Github issue# 250 -MJ",
+            "version": "21.5",
+            "revised": "2018-08-27T19:22:38Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix image",
+            "version": "21.4",
+            "revised": "2018-08-24T20:41:06Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix math\r\n",
+            "version": "21.3",
+            "revised": "2018-08-24T18:55:01Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Errata# 5801 -MJ",
+            "version": "21.2",
+            "revised": "2018-08-07T18:30:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "removed Try It solutions -MJ",
+            "version": "21.1",
+            "revised": "2018-07-24T20:48:58Z",
+            "publisher": {
+                "surname": "OpenStax College",
+                "suffix": "",
+                "firstname": "",
+                "title": "",
+                "fullname": "OpenStax",
+                "id": "OpenStaxCollege"
+            }
+        },
+        {
+            "changes": "Github issue# 1637 -MJ",
+            "version": "20.3",
+            "revised": "2018-07-20T15:50:31Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Corrected Preface -MJ",
+            "version": "20.2",
+            "revised": "2018-07-13T15:54:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "updated summary to match openstax",
+            "version": "20.1",
+            "revised": "2018-06-25T17:36:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata \"In Sec. 5.2 in the solution to the Exercise regarding the Red line, the solutions from 'c' onward are labeled improperly. 'c' should say \"\"Check students solution.\"\" And the answers now labeled 'c' through 'h' should, instead, be labled 'd' through 'i'.\r\n {gc}\"",
+            "version": "19.6",
+            "revised": "2018-06-04T21:43:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata \"\"In the homework for Sec. 3.4, the exercise about suicide rates is ambiguous. It says 'Do not include \"\"all others\"\" for parts f and g.' Therefore, I think the answer for f should be 23720/(29760 - 780).\r\n Also, think the answer for g should be 5010/(6020 - 100).\r\n {gc}\"\"",
+            "version": "19.5",
+            "revised": "2018-06-04T21:10:42Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata \"In section \"9.5 Additional Information and Full Hypothesis Test Examples\" of the online version of the book, there is a \"Try It\" problem about a right- tailed test. When you click the \"Show Solution\" button, an image appears that shows a left-tailed test. The normal distribution should be shaded to the right like the example above it. I am attaching a screenshot of the problem.\"",
+            "version": "19.4",
+            "revised": "2018-06-04T20:27:41Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata \"Delete the line \"Z~N(0,1)\"\"",
+            "version": "19.3",
+            "revised": "2018-06-04T18:41:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata \"last formula of the section for k! : Insert asterisk after (k-3) and use minus signs here.\"",
+            "version": "19.2",
+            "revised": "2018-06-04T18:24:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "New GA code",
+            "version": "19.1",
+            "revised": "2018-04-11T17:55:46Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Preface changes -MJ",
+            "version": "18.137",
+            "revised": "2018-03-06T22:18:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "links",
+            "version": "18.136",
+            "revised": "2018-03-06T18:22:14Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata 4240",
+            "version": "18.135",
+            "revised": "2018-02-22T21:18:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "fix title",
+            "version": "18.134",
+            "revised": "2018-02-21T20:10:35Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "change guideline to note",
+            "version": "18.133",
+            "revised": "2018-02-21T16:54:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "change note styling",
+            "version": "18.132",
+            "revised": "2018-02-21T15:48:39Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "preface changes",
+            "version": "18.131",
+            "revised": "2018-02-07T16:11:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #3985",
+            "version": "18.130",
+            "revised": "2018-02-02T20:00:35Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4089",
+            "version": "18.129",
+            "revised": "2018-02-02T19:54:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4178",
+            "version": "18.128",
+            "revised": "2018-02-02T19:49:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4235",
+            "version": "18.127",
+            "revised": "2018-02-02T19:46:35Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4298",
+            "version": "18.126",
+            "revised": "2018-02-02T19:42:05Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4298",
+            "version": "18.125",
+            "revised": "2018-02-02T19:41:48Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4409",
+            "version": "18.124",
+            "revised": "2018-02-02T19:32:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4411",
+            "version": "18.123",
+            "revised": "2018-02-02T19:21:50Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4483",
+            "version": "18.122",
+            "revised": "2018-02-02T19:15:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4484",
+            "version": "18.121",
+            "revised": "2018-02-02T19:05:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "errata #4512",
+            "version": "18.120",
+            "revised": "2018-02-02T18:57:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "accuracy check",
+            "version": "18.119",
+            "revised": "2017-10-17T17:13:05Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "accuracy check",
+            "version": "18.118",
+            "revised": "2017-10-17T17:06:36Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "accuracy check",
+            "version": "18.117",
+            "revised": "2017-10-17T17:03:31Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "accuracy check",
+            "version": "18.116",
+            "revised": "2017-10-17T16:03:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "accuracy check",
+            "version": "18.115",
+            "revised": "2017-10-17T14:12:31Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.114",
+            "revised": "2017-08-08T16:34:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.113",
+            "revised": "2017-08-08T15:55:22Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.112",
+            "revised": "2017-08-08T15:09:46Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.111",
+            "revised": "2017-08-07T21:24:44Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.110",
+            "revised": "2017-08-07T21:00:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.109",
+            "revised": "2017-08-07T20:47:55Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.108",
+            "revised": "2017-08-07T20:47:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.107",
+            "revised": "2017-08-07T20:47:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.106",
+            "revised": "2017-08-07T20:40:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.105",
+            "revised": "2017-08-07T20:28:16Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.104",
+            "revised": "2017-08-07T20:24:47Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.103",
+            "revised": "2017-08-07T20:16:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.102",
+            "revised": "2017-08-07T20:15:14Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.101",
+            "revised": "2017-08-07T20:14:37Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.100",
+            "revised": "2017-08-07T20:14:17Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.99",
+            "revised": "2017-08-07T20:13:34Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.98",
+            "revised": "2017-08-07T19:45:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.97",
+            "revised": "2017-08-07T19:45:05Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.96",
+            "revised": "2017-08-07T19:44:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.95",
+            "revised": "2017-08-07T19:23:47Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.94",
+            "revised": "2017-08-07T19:00:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.93",
+            "revised": "2017-08-07T19:00:06Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.92",
+            "revised": "2017-08-07T18:59:48Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.91",
+            "revised": "2017-08-07T18:59:34Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.90",
+            "revised": "2017-08-07T18:58:59Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.89",
+            "revised": "2017-08-07T18:58:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.88",
+            "revised": "2017-08-07T15:28:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.87",
+            "revised": "2017-08-07T14:49:32Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.86",
+            "revised": "2017-08-04T20:40:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.85",
+            "revised": "2017-08-04T20:39:54Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.84",
+            "revised": "2017-08-04T20:39:11Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.83",
+            "revised": "2017-08-04T20:38:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.82",
+            "revised": "2017-08-04T20:38:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.81",
+            "revised": "2017-08-04T19:44:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.80",
+            "revised": "2017-08-04T19:33:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.79",
+            "revised": "2017-08-04T19:27:14Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.78",
+            "revised": "2017-08-04T19:19:01Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.77",
+            "revised": "2017-08-04T19:18:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.76",
+            "revised": "2017-08-04T19:08:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.75",
+            "revised": "2017-08-04T18:47:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.74",
+            "revised": "2017-08-04T16:30:10Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.73",
+            "revised": "2017-08-04T15:47:38Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.72",
+            "revised": "2017-08-04T15:17:11Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.71",
+            "revised": "2017-08-03T19:41:03Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.70",
+            "revised": "2017-08-03T19:24:43Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.69",
+            "revised": "2017-08-03T19:07:46Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.68",
+            "revised": "2017-08-03T18:46:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.67",
+            "revised": "2017-08-03T18:36:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.66",
+            "revised": "2017-08-03T16:15:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.65",
+            "revised": "2017-08-03T15:59:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.64",
+            "revised": "2017-08-03T15:35:09Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.63",
+            "revised": "2017-08-03T14:52:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.62",
+            "revised": "2017-08-01T21:41:37Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.61",
+            "revised": "2017-08-01T21:38:04Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.60",
+            "revised": "2017-08-01T21:35:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.59",
+            "revised": "2017-08-01T21:29:09Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.58",
+            "revised": "2017-08-01T21:27:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.57",
+            "revised": "2017-08-01T21:24:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.56",
+            "revised": "2017-07-18T15:41:20Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.55",
+            "revised": "2017-06-13T19:37:34Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.54",
+            "revised": "2017-02-24T17:57:08Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.53",
+            "revised": "2017-02-07T17:17:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.52",
+            "revised": "2017-02-07T17:00:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.51",
+            "revised": "2017-01-31T19:26:01Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.50",
+            "revised": "2017-01-23T21:27:29Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.49",
+            "revised": "2017-01-23T21:22:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.48",
+            "revised": "2017-01-23T21:17:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.47",
+            "revised": "2017-01-23T20:42:29Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.46",
+            "revised": "2017-01-23T20:38:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.45",
+            "revised": "2017-01-23T20:31:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.44",
+            "revised": "2017-01-23T20:29:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.43",
+            "revised": "2017-01-23T20:24:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.42",
+            "revised": "2017-01-23T20:20:01Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.41",
+            "revised": "2017-01-23T20:12:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.40",
+            "revised": "2017-01-23T20:04:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.39",
+            "revised": "2017-01-23T19:21:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.38",
+            "revised": "2017-01-23T19:17:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.37",
+            "revised": "2017-01-23T19:06:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.36",
+            "revised": "2017-01-23T19:02:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.35",
+            "revised": "2017-01-23T18:56:09Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.34",
+            "revised": "2017-01-23T18:52:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.33",
+            "revised": "2017-01-23T18:43:20Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.32",
+            "revised": "2017-01-23T18:39:01Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.31",
+            "revised": "2017-01-23T18:36:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.30",
+            "revised": "2017-01-23T17:56:49Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.29",
+            "revised": "2017-01-23T17:25:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.28",
+            "revised": "2017-01-23T17:09:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.27",
+            "revised": "2017-01-23T16:42:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.26",
+            "revised": "2017-01-23T16:31:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.25",
+            "revised": "2017-01-23T16:19:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.24",
+            "revised": "2017-01-23T16:09:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.23",
+            "revised": "2017-01-23T15:56:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.22",
+            "revised": "2017-01-23T15:54:02Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.21",
+            "revised": "2017-01-23T15:29:02Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.20",
+            "revised": "2017-01-23T15:21:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.19",
+            "revised": "2017-01-20T22:07:12Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.18",
+            "revised": "2017-01-20T22:03:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.17",
+            "revised": "2017-01-20T21:50:41Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.16",
+            "revised": "2017-01-20T21:47:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.15",
+            "revised": "2017-01-20T21:39:05Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.14",
+            "revised": "2017-01-20T21:21:40Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.13",
+            "revised": "2016-10-31T19:19:38Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.12",
+            "revised": "2016-09-28T21:33:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.11",
+            "revised": "2016-07-18T21:45:12Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.10",
+            "revised": "2016-06-06T16:28:22Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.9",
+            "revised": "2016-05-18T17:02:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.8",
+            "revised": "2016-05-18T16:54:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.7",
+            "revised": "2016-05-18T16:50:36Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.6",
+            "revised": "2016-05-18T16:46:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.5",
+            "revised": "2016-05-18T16:45:42Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.4",
+            "revised": "2016-05-18T16:41:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.3",
+            "revised": "2016-05-18T16:19:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.2",
+            "revised": "2016-05-18T16:18:08Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "appendix title change",
+            "version": "18.1",
+            "revised": "2016-05-06T19:35:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.54",
+            "revised": "2016-05-06T19:31:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.53",
+            "revised": "2016-05-06T19:26:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.52",
+            "revised": "2016-05-06T19:22:36Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.51",
+            "revised": "2016-05-06T19:16:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.50",
+            "revised": "2016-05-06T19:13:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.49",
+            "revised": "2016-05-06T19:09:42Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.48",
+            "revised": "2016-05-06T19:07:05Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.47",
+            "revised": "2016-05-06T19:00:17Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.46",
+            "revised": "2016-03-22T20:08:37Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.45",
+            "revised": "2016-02-23T19:17:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.44",
+            "revised": "2015-05-13T17:50:11Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.43",
+            "revised": "2015-04-14T14:21:16Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.42",
+            "revised": "2015-03-03T14:41:27Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.41",
+            "revised": "2015-02-25T19:12:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.40",
+            "revised": "2015-02-25T15:57:36Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.39",
+            "revised": "2015-02-25T15:56:49Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.38",
+            "revised": "2015-02-19T16:16:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.37",
+            "revised": "2015-01-06T17:38:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.36",
+            "revised": "2015-01-05T23:00:40Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.35",
+            "revised": "2015-01-05T22:50:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.34",
+            "revised": "2014-10-22T21:37:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.33",
+            "revised": "2014-10-22T21:23:35Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.32",
+            "revised": "2014-10-22T21:20:12Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.31",
+            "revised": "2014-10-22T21:17:18Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.30",
+            "revised": "2014-10-22T21:14:12Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.29",
+            "revised": "2014-10-22T21:10:52Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.28",
+            "revised": "2014-10-22T21:03:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.27",
+            "revised": "2014-10-22T20:58:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.26",
+            "revised": "2014-10-22T20:51:27Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.25",
+            "revised": "2014-10-22T20:41:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.24",
+            "revised": "2014-10-22T20:38:06Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.23",
+            "revised": "2014-07-30T14:50:29Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.22",
+            "revised": "2014-07-29T19:50:31Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.21",
+            "revised": "2014-07-29T19:24:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.20",
+            "revised": "2014-06-17T16:49:26Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.19",
+            "revised": "2014-06-11T21:25:03Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.18",
+            "revised": "2014-06-11T15:56:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.17",
+            "revised": "2014-06-11T15:55:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.16",
+            "revised": "2014-06-11T15:47:17Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.15",
+            "revised": "2014-06-11T15:47:03Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.14",
+            "revised": "2014-06-11T15:44:49Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.13",
+            "revised": "2014-06-11T15:37:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.12",
+            "revised": "2014-06-11T15:25:29Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.11",
+            "revised": "2014-06-11T15:12:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.10",
+            "revised": "2014-06-11T15:05:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.9",
+            "revised": "2014-06-11T14:29:06Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.8",
+            "revised": "2014-06-11T14:10:23Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.7",
+            "revised": "2014-06-11T13:57:50Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.6",
+            "revised": "2014-06-10T22:06:06Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.5",
+            "revised": "2014-06-10T22:01:59Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.4",
+            "revised": "2014-06-10T21:25:16Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.3",
+            "revised": "2014-06-10T21:23:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.2",
+            "revised": "2014-06-10T21:22:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "separated stats labs into their own modules, deleted them from modules formerly containing them",
+            "version": "17.1",
+            "revised": "2014-05-09T16:27:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.75",
+            "revised": "2014-05-09T16:06:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.74",
+            "revised": "2014-05-09T15:53:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.73",
+            "revised": "2014-05-09T15:38:49Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.72",
+            "revised": "2014-05-09T15:28:34Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.71",
+            "revised": "2014-05-09T14:50:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.70",
+            "revised": "2014-05-09T14:20:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.69",
+            "revised": "2014-05-09T00:51:21Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.68",
+            "revised": "2014-05-08T22:07:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.67",
+            "revised": "2014-05-08T21:59:09Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.66",
+            "revised": "2014-05-08T21:47:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.65",
+            "revised": "2014-05-08T21:47:12Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.64",
+            "revised": "2014-05-08T21:46:31Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.63",
+            "revised": "2014-04-07T20:03:51Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.62",
+            "revised": "2014-01-30T20:57:42Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.61",
+            "revised": "2014-01-30T20:34:01Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.60",
+            "revised": "2014-01-30T20:27:48Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.59",
+            "revised": "2014-01-30T20:25:43Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.58",
+            "revised": "2014-01-30T19:41:10Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.57",
+            "revised": "2014-01-30T19:36:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.56",
+            "revised": "2014-01-30T19:26:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.55",
+            "revised": "2014-01-27T15:04:20Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.54",
+            "revised": "2014-01-23T23:12:43Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.53",
+            "revised": "2014-01-23T19:59:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.52",
+            "revised": "2014-01-23T19:49:59Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.51",
+            "revised": "2014-01-23T19:48:11Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.50",
+            "revised": "2014-01-23T19:40:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.49",
+            "revised": "2014-01-23T19:35:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.48",
+            "revised": "2014-01-23T19:31:08Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.47",
+            "revised": "2014-01-23T19:16:41Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.46",
+            "revised": "2014-01-22T18:02:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.45",
+            "revised": "2014-01-22T17:56:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.44",
+            "revised": "2014-01-22T17:40:33Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.43",
+            "revised": "2014-01-22T17:30:37Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.42",
+            "revised": "2014-01-22T17:27:15Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.41",
+            "revised": "2014-01-17T16:15:48Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.40",
+            "revised": "2014-01-17T16:15:08Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.39",
+            "revised": "2014-01-17T16:12:04Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.38",
+            "revised": "2014-01-17T16:08:24Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.37",
+            "revised": "2014-01-17T16:05:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.36",
+            "revised": "2014-01-17T16:03:14Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.35",
+            "revised": "2014-01-17T15:33:39Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.34",
+            "revised": "2014-01-17T15:30:07Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.33",
+            "revised": "2014-01-15T16:52:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.32",
+            "revised": "2014-01-15T16:42:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.31",
+            "revised": "2014-01-14T22:55:40Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.30",
+            "revised": "2014-01-14T21:56:10Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.29",
+            "revised": "2014-01-14T21:54:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.28",
+            "revised": "2014-01-14T21:38:10Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.27",
+            "revised": "2014-01-14T20:35:46Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.26",
+            "revised": "2014-01-14T20:31:08Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.25",
+            "revised": "2014-01-14T20:19:43Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.24",
+            "revised": "2014-01-14T16:11:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.23",
+            "revised": "2014-01-14T16:01:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.22",
+            "revised": "2014-01-14T15:53:34Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.21",
+            "revised": "2014-01-14T15:28:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.20",
+            "revised": "2014-01-14T15:05:25Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.19",
+            "revised": "2014-01-14T14:56:17Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.18",
+            "revised": "2014-01-14T14:54:22Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.17",
+            "revised": "2014-01-13T20:04:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.16",
+            "revised": "2014-01-13T20:00:23Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.15",
+            "revised": "2014-01-13T19:53:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.14",
+            "revised": "2014-01-13T19:51:04Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.13",
+            "revised": "2014-01-09T22:15:57Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.12",
+            "revised": "2014-01-09T22:02:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.11",
+            "revised": "2014-01-09T21:52:00Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.10",
+            "revised": "2014-01-09T21:45:19Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.9",
+            "revised": "2014-01-09T21:28:13Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.8",
+            "revised": "2014-01-09T21:11:14Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.7",
+            "revised": "2013-12-18T20:50:30Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.6",
+            "revised": "2013-12-18T19:01:08Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.5",
+            "revised": "2013-12-17T22:22:56Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.4",
+            "revised": "2013-12-17T22:12:02Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.3",
+            "revised": "2013-12-17T16:02:03Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.2",
+            "revised": "2013-12-16T19:49:46Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "modified ch 9 and 10 titles",
+            "version": "16.1",
+            "revised": "2013-12-13T22:19:23Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "changes roles",
+            "version": "15.1",
+            "revised": "2013-12-05T16:42:23Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Removed appendix H. It has been assimilated. ",
+            "version": "14.1",
+            "revised": "2013-12-04T19:21:04Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "exploded appendices",
+            "version": "13.1",
+            "revised": "2013-12-02T23:02:09Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "reordered chapter 2",
+            "version": "12.1",
+            "revised": "2013-11-18T18:57:53Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "added summary and keywords",
+            "version": "11.1",
+            "revised": "2013-11-06T20:34:11Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "rearranged appendix I",
+            "version": "10.1",
+            "revised": "2013-10-29T18:27:41Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Added appendices",
+            "version": "9.1",
+            "revised": "2013-10-29T18:08:16Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "added preface",
+            "version": "8.1",
+            "revised": "2013-10-23T15:11:58Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "replaced last module of chapter 3",
+            "version": "7.1",
+            "revised": "2013-10-22T19:20:50Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "deleted unused modules",
+            "version": "6.1",
+            "revised": "2013-10-21T14:01:28Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "Removed deleted modules",
+            "version": "5.1",
+            "revised": "2013-10-14T15:40:45Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "reorganized chapter 1 according to updated bookmap",
+            "version": "4.1",
+            "revised": "2013-09-19T16:31:54Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "added tracking number, changed style parameter to CCAP Statistics",
+            "version": "3.1",
+            "revised": "2013-09-19T15:24:59Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "updated title",
+            "version": "2.1",
+            "revised": "2013-08-27T15:21:46Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        },
+        {
+            "changes": "publish",
+            "version": "1.1",
+            "revised": "2013-08-23T16:30:47Z",
+            "publisher": {
+                "surname": "Statistics",
+                "suffix": "",
+                "firstname": "OpenStax",
+                "title": "",
+                "fullname": "OpenStax College",
+                "id": "cnxstats"
+            }
+        }
+    ]
+}

--- a/nebu/tests/models/conftest.py
+++ b/nebu/tests/models/conftest.py
@@ -2,12 +2,24 @@ import pytest
 
 
 @pytest.fixture
-def collection_data(datadir):
+def neb_collection_data(datadir):
     """This data is the result of a ``neb get ...``"""
     return datadir / 'collection_for_bakedpdf_workflow'
 
 
 @pytest.fixture
-def assembled_data(datadir):
+def neb_assembled_data(datadir):
     """This data is the results of a ``neb assemble ...``"""
     return datadir / 'assembled_collection_for_bakedpdf_workflow'
+
+
+@pytest.fixture
+def git_collection_data(datadir):
+    """This data reflects what is expected from git storage"""
+    return datadir / 'collection_for_git_workflow'
+
+
+@pytest.fixture
+def git_assembled_data(datadir):
+    """This data is the results of a ``neb assemble ...``"""
+    return datadir / 'assembled_collection_for_git_workflow'

--- a/nebu/tests/models/test_binder.py
+++ b/nebu/tests/models/test_binder.py
@@ -103,6 +103,8 @@ class TestBinder(object):
             'title': 'Introductory Statistics',
             'translators': [],
             'version': '23.41',
+            'uuid': None,
+            'canonical_book_uuid': None,
         }
         assert binder.metadata == expected_metadata
 

--- a/nebu/tests/models/test_binder.py
+++ b/nebu/tests/models/test_binder.py
@@ -8,8 +8,8 @@ from nebu.models.binder import Binder
 
 class TestBinder(object):
 
-    def test_from_collection_xml(self, collection_data):
-        filepath = collection_data / 'collection.xml'
+    def test_from_collection_xml(self, neb_collection_data):
+        filepath = neb_collection_data / 'collection.xml'
 
         # Hit the target
         binder = Binder.from_collection_xml(filepath)
@@ -174,3 +174,142 @@ class TestBinder(object):
             assert expected.get(doc.id)
             for reference in doc.references:
                 assert reference.uri in expected[doc.id]
+
+    def test_from_git_collection_xml(self, git_collection_data):
+        filepath = git_collection_data / 'collection.xml'
+
+        # Hit the target
+        binder = Binder.from_collection_xml(filepath)
+
+        # Verify the tree structure
+        expected_tree = {
+            'contents': [
+                {'id': 'm47830@1.17',
+                 'shortId': None,
+                 'title': 'Preface'},
+                {'contents': [{'id': 'd93df8ff-6e4a-4a5e-befc-ba5a144f309c@',
+                               'shortId': None,
+                               'title': 'Introduction'},
+                              {'id': 'cb418599-f69b-46c1-b0ef-60d9e36e677f@',
+                               'shortId': None,
+                               'title': 'Definitions of '
+                               'Statistics, Probability, '
+                               'and Key Terms'},
+                              {'id': 'm46885@1.21',
+                               'shortId': None,
+                               'title': 'Data, Sampling, and '
+                               'Variation in Data and '
+                               'Sampling'},
+                              {'id': '3fb20c92-9515-420b-ab5e-6de221b89e99@',
+                               'shortId': None,
+                               'title': 'Frequency, Frequency '
+                               'Tables, and Levels of '
+                               'Measurement'},
+                              {'id': 'm46919@1.13',
+                               'shortId': None,
+                               'title': 'Experimental Design and '
+                               'Ethics'}],
+                 'id': 'subcol',
+                 'shortId': None,
+                 'title': 'Sampling and Data'},
+                {'contents': [{'id': 'm46925@1.7',
+                               'shortId': None,
+                               'title': 'Introduction'},
+                              {'id': 'm46934@1.10',
+                               'shortId': None,
+                               'title': 'Stem-and-Leaf Graphs '
+                               '(Stemplots), Line Graphs, '
+                               'and Bar Graphs'}],
+                 'id': 'subcol',
+                 'shortId': None,
+                 'title': 'Descriptive Statistics'},
+                {'id': 'm47864@1.17',
+                 'shortId': None,
+                 'title': 'Review Exercises (Ch 3-13)'},
+                {'id': 'm47865@1.16',
+                 'shortId': None,
+                 'title': 'Practice Tests (1-4) and Final Exams'},
+                {'id': 'm47873@1.9',
+                 'shortId': None,
+                 'title': 'Data Sets'}],
+            'id': '30189442-6998-4686-ac05-ed152b91b9de@23.41',
+            'shortId': None,
+            'title': 'Introductory Statistics',
+        }
+        assert model_to_tree(binder) == expected_tree
+
+        # Verify the metadata
+        expected_metadata = {
+            'authors': [{'id': 'OpenStaxCollege',
+                         'name': 'OpenStaxCollege',
+                         'type': 'cnx-id'}],
+            'cnx-archive-shortid': None,
+            'cnx-archive-uri': '30189442-6998-4686-ac05-ed152b91b9de@23.41',
+            'copyright_holders': [{'id': 'OpenStaxCollege',
+                                   'name': 'OpenStaxCollege',
+                                   'type': 'cnx-id'}],
+            'created': '2013-07-18T19:30:26-05:00',
+            'derived_from_title': None,
+            'derived_from_uri': None,
+            'editors': [],
+            'illustrators': [],
+            'keywords': (),
+            'language': 'en',
+            'license_text': 'CC BY',
+            'license_url': 'http://creativecommons.org/licenses/by/4.0/',
+            'print_style': 'statistics',
+            'publishers': [{'id': 'OpenStaxCollege',
+                            'name': 'OpenStaxCollege',
+                            'type': 'cnx-id'},
+                           {'id': 'cnxstats',
+                            'name': 'cnxstats',
+                            'type': 'cnx-id'}],
+            'revised': '2019-02-22T14:15:14.840187-06:00',
+            'subjects': ('Mathematics and Statistics',),
+            'summary': None,
+            'title': 'Introductory Statistics',
+            'translators': [],
+            'version': '23.41',
+            'uuid': None,
+            'canonical_book_uuid': None,
+        }
+        assert binder.metadata == expected_metadata
+
+        # Verify documents have been created
+        expected = [
+            'd93df8ff-6e4a-4a5e-befc-ba5a144f309c',
+            'cb418599-f69b-46c1-b0ef-60d9e36e677f',
+            '3fb20c92-9515-420b-ab5e-6de221b89e99'
+        ]
+        assert [x.id for x in flatten_to_documents(binder)] == expected
+
+        # Verify the collection title overrides
+        custom_title_doc = [
+            doc
+            for doc in flatten_to_documents(binder)
+            if doc.id == 'd93df8ff-6e4a-4a5e-befc-ba5a144f309c'
+        ][0]
+        # the page believes its title is...
+        title = 'Introduction to Statistics'
+        assert custom_title_doc.metadata['title'] == title
+        # ...and the book believes the title is...
+        title = 'Introduction'
+        assert binder[1].get_title_for_node(custom_title_doc) == title
+
+        # Verify the DocumentPointer objects have a title set on the object
+        doc_pt = binder[0]
+        title = 'Preface'
+        assert doc_pt.metadata['title'] == title
+
+        # Verify cnx-archive-uri is set in modules with metadata
+        expected = {
+            '3fb20c92-9515-420b-ab5e-6de221b89e99':
+                '3fb20c92-9515-420b-ab5e-6de221b89e99@',
+            'cb418599-f69b-46c1-b0ef-60d9e36e677f':
+                'cb418599-f69b-46c1-b0ef-60d9e36e677f@',
+            'd93df8ff-6e4a-4a5e-befc-ba5a144f309c':
+                'd93df8ff-6e4a-4a5e-befc-ba5a144f309c@'
+        }
+        for doc in flatten_to_documents(binder):
+            assert expected.get(doc.id)
+            assert expected[doc.id] == doc.metadata['cnx-archive-uri']

--- a/nebu/tests/models/test_document.py
+++ b/nebu/tests/models/test_document.py
@@ -36,6 +36,7 @@ M46882_METADATA = {
     'title': 'Frequency, Frequency Tables, and Levels of Measurement',
     'translators': [],
     'version': '1.17',
+    'canonical_book_uuid': None,
 }
 
 
@@ -97,7 +98,9 @@ class TestDocument(object):
 
         # Verify the metadata
         assert doc.id == 'm46882'
-        expected_metadata = M46882_METADATA
+        expected_metadata = copy(M46882_METADATA)
+        # When parsing from index.cnxml, neb uses the cnxml metadata parser
+        expected_metadata['uuid'] = None
         assert doc.metadata == expected_metadata
 
         # Verify the content is content'ish

--- a/nebu/tests/models/test_resource.py
+++ b/nebu/tests/models/test_resource.py
@@ -5,9 +5,9 @@ from cnxepub.models import RESOURCE_HASH_TYPE
 from nebu.models.resource import FileSystemResource
 
 
-def test(collection_data):
+def test(request, neb_collection_data):
     filename = 'CNX_Stats_C01_M10_003.jpg'
-    filepath = collection_data / 'm46882' / filename
+    filepath = neb_collection_data / 'm46882' / filename
 
     # Create the resource object (target)
     res = FileSystemResource(filepath)

--- a/nebu/tests/models/test_utils.py
+++ b/nebu/tests/models/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from copy import copy
 from pathlib import Path
 
@@ -159,8 +160,11 @@ class TestScanForIdMapping(object):
             for k, v in results.items()
         }
 
-    def test(self, collection_data):
+    @pytest.mark.parametrize(
+        'collection', ['neb_collection_data', 'git_collection_data'])
+    def test(self, request, collection):
         # Call the target
+        collection_data = request.getfixturevalue(collection)
         id_to_path_mapping = scan_for_id_mapping(collection_data)
 
         # Check the results
@@ -237,7 +241,10 @@ class TestScanForUUIDMapping(object):
             for k, v in results.items()
         }
 
-    def test(self, collection_data):
+    @pytest.mark.parametrize(
+        'collection', ['neb_collection_data', 'git_collection_data'])
+    def test(self, request, collection):
+        collection_data = request.getfixturevalue(collection)
         # Call the target
         uuid_to_path_mapping = scan_for_uuid_mapping(collection_data)
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,7 +1,7 @@
 lxml==4.4.3
 click>=7.1.2
 cnxml>=3.1.1
-cnx-epub>=0.25.0
+cnx-epub>=0.26.1
 cnx-litezip>=1.6.0
 cnx-transforms>=1.2.1
 docker>=4.2.2

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,6 +1,6 @@
 lxml==4.4.3
 click>=7.1.2
-cnxml>=3.1.0
+cnxml>=3.1.1
 cnx-epub>=0.25.0
 cnx-litezip>=1.6.0
 cnx-transforms>=1.2.1


### PR DESCRIPTION
Notes to help with code review:

* The core code changes in this PR are limited to [this commit](https://github.com/openstax/nebuchadnezzar/pull/189/commits/9518d96c9ed5366651a0490f78d2f50605fc543f) which implements the fallback logic
* There are a couple of commits that update dependencies for [cnxml](https://github.com/openstax/nebuchadnezzar/pull/189/commits/e1f991f87bca263b60ece92deaca4dbe3d42ad91) and [cnx-epub](https://github.com/openstax/nebuchadnezzar/pull/189/commits/a22c49c808ce50007c68990d06897cf444023132)
* The remainder of the commits are for test updates including [creating dedicated fixtures for git workflow](https://github.com/openstax/nebuchadnezzar/pull/189/commits/221f23b9a979e5f6f3131273fc21bf6482e82478) so we can test the differences between archive and git more readily both in this PR as well as future changes that we'll likely need for book metadata, etc. 