### PR TITLE
Ignore derived-from metadata when setting titles

### DIFF
--- a/nebu/models/binder.py
+++ b/nebu/models/binder.py
@@ -32,6 +32,7 @@ COLLXML_TOPIC_TAGS = (
 VERSION_ATTRIB_NAME = (
     '{http://cnx.rice.edu/system-info}version-at-this-collection-version'
 )
+DERIVED_FROM_TAG = '{http://cnx.rice.edu/mdml}derived-from'
 DOC_TYPES = (Document, DocumentPointer,)
 
 
@@ -78,8 +79,17 @@ class Binder(BaseBinder):
         parent_node = current_node = binder
         chain = [binder]
 
+        ignoring = False
+
         def handler(event, elm):
-            nonlocal parent_node, current_node
+            nonlocal parent_node, current_node, ignoring
+            if elm.tag == DERIVED_FROM_TAG:
+                if event == 'start':
+                    ignoring = True
+                elif event == 'end':
+                    ignoring = False
+            if ignoring:
+                return
             if elm.tag == TITLE_TAG and event == 'start':
                 title = elm.text
                 if isinstance(current_node, DOC_TYPES):

--- a/nebu/tests/data/collection_for_bakedpdf_workflow/collection.xml
+++ b/nebu/tests/data/collection_for_bakedpdf_workflow/collection.xml
@@ -38,6 +38,40 @@
     <md:subjectlist>
       <md:subject>Mathematics and Statistics</md:subject>
     </md:subjectlist>
+    <!-- Let's go ahead and pretend this derives from an econ book. Spoopy! -->
+    <md:derived-from url="https://legacy.cnx.org/content/col11613/1.2">
+      <!-- WARNING! The 'metadata' section is read only. Do not edit below. Changes to the metadata section in the source will not be saved. -->
+      <md:repository>https://legacy.cnx.org/content</md:repository>
+      <md:content-url>https://legacy.cnx.org/content/col11613/1.2</md:content-url>
+      <md:content-id>col11613</md:content-id>
+      <md:title>Principles of Economics</md:title>
+      <md:version>1.2</md:version>
+      <md:created>2014-01-02T16:13:54-06:00</md:created>
+      <md:revised>2014-02-12T15:06:58.908179-06:00</md:revised>
+      <md:language>en</md:language>
+      <md:license url="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution License</md:license>
+      <!-- For information on license requirements for use or modification, see license url in the above <md:license> element.
+          For information on formatting required attribution, see the URL:
+            CONTENT_URL/content_info#cnx_cite_header
+          where CONTENT_URL is the value provided above in the <md:content-url> element.
+      -->
+      <md:actors>
+        <md:person userid="cnxecon">
+          <md:firstname>OpenStax</md:firstname>
+          <md:surname>Economics</md:surname>
+          <md:fullname>OpenStax College</md:fullname>
+          <md:email>info@openstaxcollege.org</md:email>
+        </md:person>
+      </md:actors>
+      <md:roles>
+        <md:role type="author">cnxecon</md:role>
+        <md:role type="maintainer">cnxecon</md:role>
+        <md:role type="licensor">cnxecon</md:role>
+      </md:roles>
+      <md:subjectlist>
+        <md:subject>Mathematics and Statistics</md:subject>
+      </md:subjectlist>
+    </md:derived-from>
   </metadata>
   <col:parameters>
     <col:param name="print-style" value="statistics"/>

--- a/nebu/tests/models/test_binder.py
+++ b/nebu/tests/models/test_binder.py
@@ -82,8 +82,8 @@ class TestBinder(object):
                                    'name': 'OpenStaxCollege',
                                    'type': 'cnx-id'}],
             'created': '2013-07-18T19:30:26-05:00',
-            'derived_from_title': None,
-            'derived_from_uri': None,
+            'derived_from_title': 'Principles of Economics',
+            'derived_from_uri': 'https://legacy.cnx.org/content/col11613/1.2',
             'editors': [],
             'illustrators': [],
             'keywords': (),
@@ -98,7 +98,11 @@ class TestBinder(object):
                             'name': 'cnxstats',
                             'type': 'cnx-id'}],
             'revised': '2019-02-22T14:15:14.840187-06:00',
-            'subjects': ('Mathematics and Statistics',),
+            # FIXME: Subject from derived-from is duplicated here
+            # This is a problem with the cnxml library, not neb
+            # Same problem will exist with keywords and potentially roles
+            'subjects': ('Mathematics and Statistics',
+                         'Mathematics and Statistics'),
             'summary': None,
             'title': 'Introductory Statistics',
             'translators': [],


### PR DESCRIPTION
A diff of the assembled book before and after the change:
```
4c4
<     <title>Principles of Economics</title>
---
>     <title>Principles of Macroeconomics</title>
20c20
<       <h1 data-type="document-title" itemprop="name">Principles of Economics</h1>
---
>       <h1 data-type="document-title" itemprop="name">Principles of Macroeconomics</h1>
```