### PR TITLE
Follow the initial redirect in `neb get` explicitly

### DIFF
--- a/nebu/cli/get.py
+++ b/nebu/cli/get.py
@@ -184,7 +184,15 @@ def get_collection_metadata(session,
 
     # Request the collection's metadata by requests the legacy url,
     # which is redirected to the metadata url.
-    resp = session.get(url)
+    resp = session.get(url, allow_redirects=False)
+
+    # Users outside the US encountered an error instead of
+    # following the redirect so we explicitly follow it
+    # in this case.
+    if (resp.status_code == 301 or resp.status_code == 302):
+        url = resp.headers['Location']
+        resp = session.get(url, allow_redirects=False)
+
     if resp.status_code >= 400:
         raise MissingContent(col_id, req_version)
     col_metadata = resp.json()

--- a/nebu/cli/session.py
+++ b/nebu/cli/session.py
@@ -12,6 +12,7 @@ class NebSession(requests.Session):
             }
         )
 
-    @backoff.on_exception(backoff.expo, requests.exceptions.ConnectionError)
+    @backoff.on_exception(backoff.expo,
+                          requests.exceptions.ConnectionError, max_tries=6)
     def request(self, *args, **kwargs):
         return super(NebSession, self).request(*args, **kwargs)


### PR DESCRIPTION
Also, limit the number of retries so that backoff does not continue indefinitely.

Refs https://github.com/openstax/cnx/issues/1674