### PR TITLE
Update cnxml from 3.1.7 to 3.1.8

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,6 +1,6 @@
 lxml==4.4.3
 click>=7.1.2
-cnxml>=3.1.7
+cnxml>=3.1.8
 cnx-epub>=0.32.0
 cnx-litezip>=1.6.0
 cnx-transforms>=1.8.0


### PR DESCRIPTION
This update adds a Polish license and makes an empty url attribute on a md:license tag resolve to None so that the default license will be used.

Note, we recently updated the default license to include the text '(ASSUMED)'. This might become a more visible change since at least two derived books have empty license urls.