### PR TITLE
Fix strong tags being given the data-type=bold attribute

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+9.16.0
+
+- Fix strong tags being given the data-type=bold attribute
+
 9.15.0
 
 - Ensure all IDs are unique and remove randomly-generated IDs

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -3,7 +3,7 @@ click>=7.1.2
 cnxml>=3.1.8
 cnx-epub>=0.32.0
 cnx-litezip>=1.6.0
-cnx-transforms>=1.8.0
+cnx-transforms>=1.9.0
 docker>=4.2.2
 pip
 requests>=2.24.0


### PR DESCRIPTION
- [x] openstax/rhaptos.cnxmlutils#208
- [x] https://github.com/openstax/cnx-recipes/issues/3870