### PR TITLE
upgrade lxml

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,4 +1,4 @@
-lxml==4.4.3
+lxml==4.9.2
 click>=7.1.2
 docker>=4.2.2
 pip


### PR DESCRIPTION
for arm containers (they require ubuntu 22 because of PrinceXML)

refs https://github.com/openstax/enki/pull/197