### PR TITLE
upgrades lxml

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,4 +1,4 @@
-lxml==4.4.3
+lxml==4.9.2
 click>=7.1.2
 docker>=4.2.2
 pip


### PR DESCRIPTION
because older ones do not have prebuilt binaries for ARM devices (they require ubuntu 22 because of PrinceXML)

refs https://github.com/openstax/enki/pull/197

# Testing

- This will require regression-testing all of the books, the likely culprits are ones with unicode characters (emoji and non-english book)